### PR TITLE
Add generalized AIR suite template and a Solution Owner review

### DIFF
--- a/adversarial-iterative-refinement/PLATFORM-ENGINEERING-REVIEW.md
+++ b/adversarial-iterative-refinement/PLATFORM-ENGINEERING-REVIEW.md
@@ -1,0 +1,36 @@
+# Platform Engineering Review
+
+This review is part of the [Adversarial Iterative Refinement (AIR)](README.md) suite. It is a required gate for merging. See [README.md](README.md) for sequencing, scoped runs, and domain coordination.
+
+The purpose of this review is to shift quality checks left — into the CI/CD pipeline — so that defects are caught automatically before merging or deploying, rather than relying on manual review steps. Every review evaluates the whole pipeline, not only steps that changed.
+
+## Current Review Prompt
+
+**Scope:** Whole pipeline and build configuration by default. If a scope is provided (e.g., a specific workflow file or build config change), focus primary analysis there — but regression checks always cover the entire pipeline.
+
+Read all workflow files, build config, package manifests, lock files, and `.gitignore`. Apply every standard dimension below as a floor — add others as appropriate to the current state of the pipeline. There is no restriction on what can be flagged.
+
+For each finding, cite file and line number. Classify as **resolved** (fix applied this review), **deferred** (scheduled for a specific layer, reason given), or **dismissed** (no action taken, rationale required).
+
+Regression check: verify that all pipeline gates installed in prior reviews are still present and still gate on failure. A refactor to one part of the pipeline can silently remove a gate.
+
+**Left-shift lens:** For every manual check in the project's AIR gate checklists, evaluate whether it can be automated and moved into CI. Automating a check is always preferable to a human remembering to run it.
+
+**Coordination:** Flag any findings that should be surfaced to [QA-REVIEW.md](QA-REVIEW.md), [UX-REVIEW.md](UX-REVIEW.md), [SECURITY-REVIEW.md](SECURITY-REVIEW.md), or [SOLUTION-ARCHITECT-REVIEW.md](SOLUTION-ARCHITECT-REVIEW.md). If this review suggests the need for a new AIR domain, log it as a finding.
+
+## Standard Evaluation Dimensions
+
+1. **Pipeline completeness** — Does CI run all required checks: typecheck, unit tests, coverage, browser tests, build, audit? Are any quality gates manual-only that could be automated?
+2. **Gate enforcement** — Are all pipeline checks required to pass before merging? Is branch protection configured?
+3. **Dependency installation** — Is `npm ci` used (not `npm install`)? Is the lock file committed and the source of truth for installs?
+4. **Environment pinning** — Is the runtime version (Node, etc.) pinned? Are browser versions for testing deterministic?
+5. **Cache correctness** — Are cache keys scoped to the right artifacts? Will caches invalidate when dependencies or configs change?
+6. **Coverage thresholds** — Are coverage requirements enforced in CI with configured thresholds, not just available locally?
+7. **Security scanning** — Is `npm audit` or equivalent run in CI and configured to fail on findings above the accepted risk threshold?
+8. **Artifact hygiene** — Is build output excluded from version control? Is it generated fresh in CI, never committed?
+9. **Action/dependency pinning** — Are CI action versions pinned to avoid supply chain risk? Are they up to date?
+10. **Left-shift opportunities** — Which manual review steps could be automated and added to CI?
+
+---
+
+Review entries are logged in `adversarial-iterative-refinement/PLATFORM-ENGINEERING-REVIEW.md` inside the project being reviewed.

--- a/adversarial-iterative-refinement/QA-REVIEW.md
+++ b/adversarial-iterative-refinement/QA-REVIEW.md
@@ -1,0 +1,38 @@
+# QA Review
+
+This review is part of the [Adversarial Iterative Refinement (AIR)](README.md) suite. It is a required gate for merging. See [README.md](README.md) for sequencing, scoped runs, and domain coordination.
+
+The purpose of this review is to apply iterative adversarial pressure to find, document, and resolve bugs, logic errors, test weaknesses, coverage gaps, and regressions. Every review targets the whole application — not only the most recently changed code.
+
+## Current Review Prompt
+
+**Scope:** Whole application by default. If a scope is provided (e.g., a specific feature or set of changed files), focus primary analysis there — but regression checks always cover the entire application.
+
+Read all source files, test files, HTML, CSS, and config. Apply every standard dimension below as a floor — add others as appropriate to the current state of the app. There is no restriction on what can be flagged.
+
+For each finding, cite file and line number. Classify as **resolved** (fix applied this review), **deferred** (scheduled for a specific layer, reason given), or **dismissed** (no action taken, rationale required).
+
+Regression check: verify that all previously-working features still work. Prior layers' acceptance criteria are always in scope. A change to one part of the app can silently break another. A bug that was always present is still a bug.
+
+**Coordination:** Flag any findings that should be surfaced to [UX-REVIEW.md](UX-REVIEW.md), [SECURITY-REVIEW.md](SECURITY-REVIEW.md), [PLATFORM-ENGINEERING-REVIEW.md](PLATFORM-ENGINEERING-REVIEW.md), or [SOLUTION-ARCHITECT-REVIEW.md](SOLUTION-ARCHITECT-REVIEW.md). If this review suggests the need for a new AIR domain, log it as a finding.
+
+## Standard Evaluation Dimensions
+
+1. **Acceptance criteria** — Are all criteria actually met by the implementation, not just implied?
+2. **Test falsifiability** — Would each unit and browser test catch a broken implementation? Could any test pass against wrong code?
+3. **Selector strength** — Are test selectors tight enough to fail on a broken implementation?
+4. **Validation gaps** — What inputs slip through? What edge cases are untested?
+5. **Logic errors** — Are there bugs or off-by-one errors in the core logic?
+6. **Dead code** — Any exported or declared code with no call sites?
+7. **Unused dependencies** — Any direct dependencies not imported or used?
+8. **Dependency versions** — Are versions appropriate and not significantly outdated?
+9. **Coverage gaps** — Does the coverage report reveal untested branches or functions that correspond to acceptance criteria?
+10. **Accessibility** — Is semantic HTML used correctly (landmarks, headings, lists)? Do all interactive elements have accessible labels? Is keyboard navigation complete? Are focus states visible? Are ARIA roles or attributes missing? Run axe and confirm zero violations.
+11. **Browser compatibility** — Any JavaScript APIs, CSS properties, or HTML features that behave differently in Firefox or Safari?
+12. **Responsive design** — Does the layout hold at 360px? Are touch targets at least 44×44px? Does content reflow cleanly?
+13. **Security surface** — Is user content rendered safely? Are user-supplied URLs validated? Is storage data runtime-validated? Any new CVEs in dependencies?
+14. **Regression coverage** — Does every bug logged in the review log have an identifiable regression test? Flag any whose regression path is untested.
+
+---
+
+Review entries are logged in `adversarial-iterative-refinement/QA-REVIEW.md` inside the project being reviewed.

--- a/adversarial-iterative-refinement/README.md
+++ b/adversarial-iterative-refinement/README.md
@@ -1,0 +1,78 @@
+# Adversarial Iterative Refinement (AIR)
+
+AIR applies iterative adversarial pressure across multiple review domains to find, document, and resolve defects before merging. Every layer must pass a full AIR run before it may be merged.
+
+## Domains
+
+| Domain | Prompt file | Focus |
+|---|---|---|
+| QA | [QA-REVIEW.md](QA-REVIEW.md) | Correctness, test coverage, falsifiability, logic errors, dead code, dependencies, accessibility, browser compatibility, responsive design, security surface, regression coverage |
+| UX | [UX-REVIEW.md](UX-REVIEW.md) | Empty states, error messages, focus and keyboard behavior, visual consistency, affordances, feedback patterns, accessibility, responsive design, browser compatibility, long content, reduced motion, native dialog quality |
+| Security | [SECURITY-REVIEW.md](SECURITY-REVIEW.md) | Rendering safety, URL injection, storage validation, dependency CVEs, CSP, information exposure, input handling |
+| Platform Engineering | [PLATFORM-ENGINEERING-REVIEW.md](PLATFORM-ENGINEERING-REVIEW.md) | Pipeline completeness, gate enforcement, dependency installation, environment pinning, cache correctness, coverage thresholds, security scanning, artifact hygiene, action pinning, left-shift opportunities |
+| Solution Architect | [SOLUTION-ARCHITECT-REVIEW.md](SOLUTION-ARCHITECT-REVIEW.md) | Separation of concerns, coupling and cohesion, data model integrity, interface contracts, state management, immutability, extensibility, technology fitness, complexity budget, decision documentation |
+| Solution Owner | [SOLUTION-OWNER-REVIEW.md](SOLUTION-OWNER-REVIEW.md) | Spec coverage, scope creep, technology compliance, over-engineering, under-delivery, design fidelity, backlog candidates |
+
+Each domain file contains the current prompt and standard dimensions for that domain. Review entries are logged separately under `adversarial-iterative-refinement/` inside the project being reviewed.
+
+## Running AIR
+
+All domains may be run independently at any time. A full run is required before merging; individual domains may be invoked mid-layer to catch issues early or validate a specific concern.
+
+### Full run (required before merging)
+
+Run all domains. Domains are independent and may run in parallel. If a finding in one domain creates a new concern in another (e.g., a QA implementation change affects the security surface), flag it for that domain and sequence a targeted follow-up.
+
+### Scoped run
+
+Provide a scope to focus primary analysis on a specific feature, layer, or set of changed files. Regression checks always cover the whole application regardless of scope.
+
+Example scopes:
+- `"Layer 5 Search — src/search.ts, index.html search bar"`
+- `"handleDeleteClick in src/main.ts"`
+- `"All files changed since last AIR run"`
+
+When a scope is given, each domain reads it, concentrates its analysis there, and flags regressions it finds in unscoped areas.
+
+### Sequencing
+
+Default: run all domains in parallel. Sequence when one domain's output informs another:
+
+- Run SA first when there are significant structural or architectural changes — SA findings can change what QA, UX, and Security need to evaluate
+- Run PE first when there are significant pipeline or build config changes — other domains depend on the pipeline running correctly
+- Run Security before QA when there are significant changes to storage, rendering, or input handling — QA tests may need to cover the security-relevant paths
+- Run QA before UX when QA finds bugs that change the implementation — the UX reviewer should see the fixed version
+- Run all domains, then re-run any that received a cross-domain flag
+
+### Suggesting new domains
+
+Any domain review may propose adding a new review domain to AIR. Log it as a finding — include a proposed name, purpose statement, and an initial set of standard dimensions. If adopted, create the prompt file here, add it to the table above, and update the project's design document, task list, and PR template.
+
+Candidate domains to consider as a project grows: Performance, Internationalisation, SEO, Privacy.
+
+## Review logs
+
+Review entries are stored outside the prompt files to keep the prompts stable and reusable. Logs live at:
+
+```
+{project}/
+  adversarial-iterative-refinement/
+    QA-REVIEW.md
+    UX-REVIEW.md
+    SECURITY-REVIEW.md
+    PLATFORM-ENGINEERING-REVIEW.md
+    SOLUTION-ARCHITECT-REVIEW.md
+```
+
+Each log file follows the same structure as a review entry: scope line, then **Resolved**, **Dismissed** (and **Accepted Risk** for Security), and a **Tests:** footer line.
+
+## Merging gate
+
+Before a layer may be merged:
+
+1. All AIR domains have completed a full run scoped to that layer (or the whole project, if scope-creep is a risk)
+2. Every finding is either **resolved** (fix applied and verified) or **dismissed** (rationale documented)
+3. Accepted risks are explicitly documented with rationale
+4. Results are logged in the respective log files under `../adversarial-iterative-refinements/{project}/`
+
+No domain may be skipped. A domain with zero findings is a valid outcome — log it with `**Scope:**` and `**Tests:**` lines so the record is complete.

--- a/adversarial-iterative-refinement/SECURITY-REVIEW.md
+++ b/adversarial-iterative-refinement/SECURITY-REVIEW.md
@@ -1,0 +1,31 @@
+# Security Review
+
+This review is part of the [Adversarial Iterative Refinement (AIR)](README.md) suite. It is a required gate for merging. See [README.md](README.md) for sequencing, scoped runs, and domain coordination.
+
+The purpose of this review is to apply iterative adversarial pressure to find, document, and resolve security vulnerabilities, unsafe patterns, validation gaps, and regressions. Every review targets the whole application — not only the most recently changed code.
+
+## Current Review Prompt
+
+**Scope:** Whole application by default. If a scope is provided (e.g., a specific feature or set of changed files), focus primary analysis there — but regression checks always cover the entire application.
+
+Read all source files, test files, HTML, CSS, and config. Apply every standard dimension below as a floor — add others as appropriate to the current state of the app. There is no restriction on what can be flagged.
+
+For each finding, cite file and line number. Classify as **resolved** (fix applied this review), **accepted risk** (no fix, explicit rationale required), or **dismissed** (no action taken, rationale required).
+
+Regression check: verify that all previously-addressed security controls remain intact. Prior layers' security findings are always in scope. A change to validation, rendering, or storage handling can silently remove a control.
+
+**Coordination:** Flag any findings that should be surfaced to [QA-REVIEW.md](QA-REVIEW.md), [UX-REVIEW.md](UX-REVIEW.md), [PLATFORM-ENGINEERING-REVIEW.md](PLATFORM-ENGINEERING-REVIEW.md), or [SOLUTION-ARCHITECT-REVIEW.md](SOLUTION-ARCHITECT-REVIEW.md). If this review suggests the need for a new AIR domain, log it as a finding.
+
+## Standard Evaluation Dimensions
+
+1. **Rendering safety** — Is user-supplied content set via `.textContent` (safe) or `.innerHTML` (potentially unsafe)? Any `innerHTML` usage with user-controlled data is a finding.
+2. **URL injection** — Can a user save a URL that executes code when clicked? Verify `javascript:`, `data:`, `vbscript:`, and other non-http(s) protocols are rejected.
+3. **Storage data validation** — Is data loaded from storage validated before use? TypeScript `as` casts are compile-time only; they provide no runtime guarantee against malformed or tampered data.
+4. **Dependency security** — Are there known CVEs in direct or transitive dependencies? Check with `npm audit`.
+5. **Content Security Policy** — Is a CSP present (meta tag or response header)? Evaluate risk surface without one.
+6. **Information exposure** — Do error messages, comments, or headers reveal internal structure, stack traces, or sensitive paths?
+7. **Input handling** — Are all user inputs treated as untrusted before being stored or rendered?
+
+---
+
+Review entries are logged in `adversarial-iterative-refinement/SECURITY-REVIEW.md` inside the project being reviewed.

--- a/adversarial-iterative-refinement/SOLUTION-ARCHITECT-REVIEW.md
+++ b/adversarial-iterative-refinement/SOLUTION-ARCHITECT-REVIEW.md
@@ -1,0 +1,34 @@
+# Solution Architect Review
+
+This review is part of the [Adversarial Iterative Refinement (AIR)](README.md) suite. It is a required gate for merging. See [README.md](README.md) for sequencing, scoped runs, and domain coordination.
+
+The purpose of this review is to evaluate whether the architecture — its structure, boundaries, decisions, and tradeoffs — is sound, coherent, and appropriate for the project's stated purpose and constraints. Every review targets the whole application, not only the most recently changed code.
+
+## Current Review Prompt
+
+**Scope:** Whole application by default. If a scope is provided (e.g., a specific feature or set of changed files), focus primary analysis there — but architectural concerns frequently cross boundaries, so adjacent code is always fair game.
+
+Read all source files, the design document, and the refinement log. Apply every standard dimension below as a floor — add others as appropriate to the current state of the app. There is no restriction on what can be flagged.
+
+For each finding, cite file and line number. Classify as **resolved** (fix applied this review), **deferred** (scheduled for a specific layer, reason given), or **dismissed** (no action taken, rationale required).
+
+Regression check: verify that architectural decisions from prior layers are still intact and that new code does not silently violate established boundaries or contracts.
+
+**Coordination:** Flag any findings that should be surfaced to [QA-REVIEW.md](QA-REVIEW.md), [UX-REVIEW.md](UX-REVIEW.md), [SECURITY-REVIEW.md](SECURITY-REVIEW.md), or [PLATFORM-ENGINEERING-REVIEW.md](PLATFORM-ENGINEERING-REVIEW.md). If this review suggests the need for a new AIR domain, log it as a finding.
+
+## Standard Evaluation Dimensions
+
+1. **Separation of concerns** — Are business logic, rendering, and storage concerns cleanly separated? Do established layer boundaries hold consistently?
+2. **Coupling and cohesion** — Are modules loosely coupled? Is each module's responsibility focused and internally cohesive?
+3. **Data model integrity** — Is the data model well-defined and minimal for the use case? Are invariants enforced at the right boundaries? Are types as precise as needed?
+4. **Interface contracts** — Are the APIs between components explicit and correctly typed? Are internal conventions documented or enforced rather than implicit?
+5. **State management** — Is application state localized? Are mutations and side effects predictable and contained?
+6. **Immutability** — Are data operations consistent in their mutation patterns? Does the code avoid unexpected shared-state side effects?
+7. **Extensibility** — Can planned future features be added without restructuring? Does the architecture accommodate the project's stated growth path?
+8. **Technology fitness** — Are the chosen technologies appropriate for the stated constraints? Are tradeoffs documented?
+9. **Complexity budget** — Is complexity proportional to the problem? Are there unnecessary abstractions, over-engineering, or under-engineering for the stated scope?
+10. **Decision documentation** — Are significant architectural decisions recorded with rationale?
+
+---
+
+Review entries are logged in `adversarial-iterative-refinement/SOLUTION-ARCHITECT-REVIEW.md` inside the project being reviewed.

--- a/adversarial-iterative-refinement/SOLUTION-OWNER-REVIEW.md
+++ b/adversarial-iterative-refinement/SOLUTION-OWNER-REVIEW.md
@@ -1,0 +1,38 @@
+# Solution Owner Review
+
+This review is part of the [Adversarial Iterative Refinement (AIR)](README.md) suite. It may be run independently or alongside other domains. See [README.md](README.md) for sequencing, scoped runs, and domain coordination.
+
+The purpose of this review is to guard the project against scope creep and over-engineering. DESIGN.md is a Scope of Work — a contract. The SO review holds the implementation to that contract: 100% of what was agreed, nothing that was not. Bugs and defects are always in scope to fix. Features, behaviors, technologies, and abstractions that are not in DESIGN.md are not.
+
+**Quality does not justify scope.** A higher-quality solution that deviates from the spec is still a deviation. "Better than asked for" is not a defense. The assignment's constraints exist for a reason — pedagogical, resource, timeline, or otherwise — and the SO does not second-guess them.
+
+## Current Review Prompt
+
+**Scope:** Whole application by default. If a scope is provided (e.g., a specific layer or set of changed files), focus primary analysis there — but the full DESIGN.md is always the reference, regardless of scope.
+
+Read DESIGN.md in full before reviewing any code. Treat it as the authoritative definition of what is to be built. Then read all source files, tests, config, and dependencies. Do not be charitable toward additions. If it is not in the spec, flag it.
+
+**Start with a compliance table.** List every requirement from DESIGN.md and mark each as Met, Partial, or Missing. This is the baseline — everything else is a deviation analysis on top of it.
+
+For each finding, cite file and line number where applicable. Classify as **resolved** (fix applied this review), **backlogged** (out-of-scope item preserved for future consideration — document it with rationale), or **dismissed** (confirmed in scope — rationale required; "it's better this way" is not sufficient).
+
+Deviations from DESIGN.md that have been explicitly approved by the stakeholder prior to implementation may be classified as **approved deviation** — document the approval and the rationale.
+
+This review does not block bug fixes or defect resolution. It blocks additions.
+
+**Coordination:** Flag any out-of-scope items that other domains have recommended or resolved. The SO has veto power over additions regardless of which domain introduced them. If this review suggests the need for a new AIR domain, log it as a finding.
+
+## Standard Evaluation Dimensions
+
+1. **Spec coverage** — Is every feature, behavior, and interface element described in DESIGN.md implemented? Build the compliance table first. Identify anything required by the spec that is absent, partial, or deferred without approval.
+2. **Scope creep** — Is there anything in the implementation not described in DESIGN.md? Flag every feature, behavior, UI element, or interaction that was not agreed on — including things that are clearly useful or well-executed.
+3. **Technology compliance** — Are all technologies, libraries, and tools either explicitly called for in DESIGN.md or strictly necessary to implement it with no practical alternative? Flag anything introduced beyond the spec. Prefer simpler over more capable when both satisfy the requirement.
+4. **Over-engineering** — Is complexity added beyond what the spec requires? Flag abstractions, configurability, extensibility hooks, or generalization that serve hypothetical future requirements rather than the current assignment. A solution that requires more infrastructure, tooling, or expertise than the spec implies is over-engineered.
+5. **Under-delivery** — Are any required items missing, stubbed, or incomplete in a way that does not satisfy the spec? Partial implementations count as missing.
+6. **Backlog candidates** — For every out-of-scope item flagged, evaluate whether it has merit for a future iteration. If so, document it as a named backlog candidate with a brief rationale. Do not implement it now.
+7. **Design fidelity** — Does the implementation match the interface, data model, and behavioral descriptions in DESIGN.md? Flag divergences even if the alternative is arguably better. The spec describes what was agreed — not what is theoretically optimal.
+8. **Prior-review additions** — Did findings from other AIR domains introduce behavior, structure, or technology not covered by DESIGN.md? Each such addition requires explicit SO approval. Other domains optimize within the spec; they do not expand it.
+
+---
+
+Review entries are logged in `adversarial-iterative-refinement/SOLUTION-OWNER-REVIEW.md` inside the project being reviewed.

--- a/adversarial-iterative-refinement/UX-REVIEW.md
+++ b/adversarial-iterative-refinement/UX-REVIEW.md
@@ -1,0 +1,37 @@
+# UX Review
+
+This review is part of the [Adversarial Iterative Refinement (AIR)](README.md) suite. It is a required gate for merging. See [README.md](README.md) for sequencing, scoped runs, and domain coordination.
+
+The purpose of this review is to apply iterative adversarial pressure to find, document, and resolve UX defects, inconsistencies, accessibility gaps, and regressions. Every review targets the whole application — not only the most recently changed feature.
+
+## Current Review Prompt
+
+**Scope:** Whole application by default. If a scope is provided (e.g., a specific feature or set of changed files), focus primary analysis there — but regression checks always cover the entire application.
+
+Read all source files, styles, HTML, and tests. Apply every standard dimension below as a floor — add others as appropriate for the current state of the app. There is no restriction on what can be flagged.
+
+For each finding, cite the element, file, and line number. Classify as **resolved** (fix applied this review), **deferred** (scheduled for a specific layer, reason given), or **dismissed** (no action taken, rationale required).
+
+Regression check: verify that all previously-addressed UX concerns remain intact. Prior layers' UX changes are always in scope. A visual or interaction change to one part of the app can silently break another.
+
+**Coordination:** Flag any findings that should be surfaced to [QA-REVIEW.md](QA-REVIEW.md), [SECURITY-REVIEW.md](SECURITY-REVIEW.md), [PLATFORM-ENGINEERING-REVIEW.md](PLATFORM-ENGINEERING-REVIEW.md), or [SOLUTION-ARCHITECT-REVIEW.md](SOLUTION-ARCHITECT-REVIEW.md). If this review suggests the need for a new AIR domain, log it as a finding.
+
+## Standard Evaluation Dimensions
+
+1. **Empty states** — What does the user see when content is absent? Is there a clear prompt or explanation?
+2. **Error messages** — Are they specific, correctly placed, and do they clear at the right time?
+3. **Focus and keyboard behavior** — Can every action be completed with a keyboard alone? Does focus land in the right place when forms open or content changes?
+4. **Visual consistency** — Are equivalent UI surfaces treated the same?
+5. **Interactive affordances** — Do users know what they can interact with? Do interactive elements look interactive?
+6. **Feedback patterns** — Are success, error, loading, and empty states present and appropriate?
+7. **Accessibility** — Does every interactive element have an accessible label? Is color contrast WCAG AA compliant (4.5:1 for normal text, 3:1 for large text and UI components)? Is semantic HTML used (landmarks, headings, lists)? Are focus indicators visible? Run axe and confirm zero violations.
+8. **Responsive design** — Does the layout hold and remain usable at 360px? Are touch targets at least 44×44px? Does content reflow cleanly without horizontal scroll between mobile and desktop widths?
+9. **Browser compatibility** — Are there visual or interaction differences across Chrome, Firefox, and Safari? Are any CSS or HTML features used that render inconsistently?
+10. **Long content** — What renders when a text field contains a very long unbroken string? Does text overflow its container horizontally?
+11. **Reduced motion** — If any transitions or animations are present, are they disabled for `prefers-reduced-motion: reduce`?
+12. **Native dialog quality** — Does any `window.confirm` or `window.alert` dialog use specific, actionable text? Does it name the item being acted on?
+13. **Cross-layer regression** — Do new changes visually or interactively break features from earlier layers?
+
+---
+
+Review entries are logged in `adversarial-iterative-refinement/UX-REVIEW.md` inside the project being reviewed.


### PR DESCRIPTION
## Add generalized AIR suite template                                                                                                                                                                    
                                                                                                                                                                                                         
  ### Summary                                                                                                                                                                                              
                    
  - Adds a reusable Adversarial Iterative Refinement (AIR) suite at `adversarial-iterative-refinement/` in the portfolio root                                                                              
  - Six review domains: QA, UX, Security, Platform Engineering, Solution Architect, and a new Solution Owner domain                                                                                        
  - Each domain file contains only the prompt and standard dimensions — review logs are stored separately inside each project under `{project}/adversarial-iterative-refinement/`                          
                                                                                                                                                                                                           
  ### What this is not                                                                                                                                                                                     
                                                                                                                                                                                                           
  This is not the bookmark manager's AIR suite. That lives untouched at `bookmark-manager/adversarial-iterative-refinement/`. This is a clean, generalized template for use on future projects.            
   
  ### The Solution Owner domain                                                                                                                                                                            
                                                                                                                                                                                                         
  The other five domains in the suite are adversarial about quality: they find bugs, accessibility failures, security vulnerabilities, architectural drift, and pipeline gaps. They push the implementation
   to be better. Left unchecked, that pressure produces work that exceeds the spec — more tests, more tooling, more abstraction, more features than were agreed on. The existing domains have no mechanism
  to push back on that.                                                                                                                                                                                    
                                                                                                                                                                                                         
  The Solution Owner domain exists to apply pressure in the other direction.

  Its reference document is `DESIGN.md`, which it treats as a Scope of Work — a contract between the implementer and whoever assigned the work. A SOW defines what is to be built. Delivering more than the
   SOW describes is a deviation, not a bonus. Delivering less is also a deviation. The SO review targets 100% coverage of the agreed scope and nothing beyond it.
                                                                                                                                                                                                           
  The key rule the SO enforces: **quality does not justify scope**. A higher-quality solution that deviates from the spec is still a deviation. "It's better this way" is explicitly not a valid rationale 
  for dismissing a finding. The constraints in an assignment — use a single file, use plain JavaScript, keep it simple enough to build in a few hours — exist for reasons. Those reasons may be
  pedagogical, resource-based, timeline-based, or contractual. The SO does not second-guess them. It flags the deviation and lets the stakeholder decide.                                                  
                                                                                                                                                                                                         
  Every SO review opens with a compliance table mapping each requirement in `DESIGN.md` to Met, Partial, or Missing. This produces an objective baseline before any deviation analysis begins. The table is
   non-negotiable — it cannot be skipped or summarized away.
                                                                                                                                                                                                           
  Out-of-scope items are not simply deleted. They are evaluated as backlog candidates: if the item has merit for a future iteration, it is documented by name with a brief rationale and preserved for     
  stakeholder review. The SO is not hostile to good ideas — it is hostile to good ideas implemented without approval.
                                                                                                                                                                                                           
  The SO domain was informed by a guild reviewer's assessment of the bookmark manager project, which found that the implementation — while technically excellent — deviated significantly from the         
  assignment's explicit constraints: a single `index.html` file became four source files with a TypeScript build pipeline; "plain JavaScript" became TypeScript with ESLint and Vitest; "open in browser"
  became `npm install && npm run dev`; one or two adversarial review passes became a formalized five-domain review framework with 25+ review cycles. None of those deviations were approved. The existing  
  AIR domains had no way to catch them because they were optimizing for quality, not fidelity to the assignment.                                                                                         

  The SO is the domain that would have caught them.

  ### Test plan

  - [x] All six domain files render correctly in GitHub
  - [x] Cross-domain links within `adversarial-iterative-refinement/` resolve correctly
  - [x] README domain table links to all six domain files                                                                                                                                                  
  - [x] Log path convention (`{project}/adversarial-iterative-refinement/`) is consistent across all files and the README