### PR TITLE
issue-tracker-cli: Layer 5 — compound filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ A personal issue tracker for the terminal. Single user, no network, no accounts.
 | Layer | Feature | Status |
 |---|---|---|
 | 1 | Core create + list | ✅ Complete |
-| 2 | Status flow | 🔲 Not started |
-| 3 | Priority | 🔲 Not started |
-| 4 | Labels | 🔲 Not started |
-| 5 | Compound filtering | 🔲 Not started |
+| 2 | Status flow | ✅ Complete |
+| 3 | Priority | ✅ Complete |
+| 4 | Labels | ✅ Complete |
+| 5 | Compound filtering | 🟡 In review (PR #17) |
 | 6 | Description, show, delete | 🔲 Not started |
 | 7 | Polish (color, `--help`) | 🔲 Not started |

--- a/issue-tracker-cli/CHANGELOG.md
+++ b/issue-tracker-cli/CHANGELOG.md
@@ -1,5 +1,80 @@
 # Changelog
 
+## Layer 5 — compound filtering — 2026-05-07 00:43Z
+
+**Scope:** Closes the layer-shipping commits for Layer 5 of the assignment
+build sequence ("Compound filter — `--status`, `--priority`, `--label` AND-
+combined; correct empty-state messaging"). Layer 5's externally observable
+behavior was already emergent from the chained `retain()` calls added in
+Layer 3 (`--priority`) and Layer 4 (`--label`); this layer extracts the
+AND-logic into a named pure predicate (`issue_matches_filters`) so it is
+testable in isolation, adds explicit acceptance-criterion coverage of the
+compound paths, and ratifies the manual-testing checklist.
+
+### Changed
+
+- **`src/lib.rs`** — added private `issue_matches_filters(&Issue, &str,
+  Option<&str>, Option<&str>) -> bool` predicate AND-combining the required
+  status filter and the optional priority/label filters; refactored
+  `cmd_list`'s three chained `retain()` calls into a single `retain()` over
+  the predicate. Behavior unchanged; unit-testability gained. Rustdoc on the
+  predicate documents the caller obligation: status/priority comparisons
+  assume lowercased filter values; label comparison is case-sensitive
+  exact-match and the caller is responsible for trim normalization (per
+  DESIGN.md Edge Cases / Labels trim-on-store / trim-on-filter symmetry).
+- **`src/lib.rs#tests`** — Red Gate (commit `7d1ca57`): 5 unit tests against
+  the `todo!()` stub covering all-three-match, three single-mismatch
+  subcases, status-only wildcard, status-mismatch-with-optionals-absent, and
+  case-sensitive label match. Round 2 (commit `7f9bae4`):
+  `filter_and_logic_is_not_or_between_optional_conjuncts` defense-in-depth
+  added per QE Review 13 Finding 1 — kills the inter-conjunct `&&`→`||`
+  mutation that all five Round-1 unit tests survive.
+- **`tests/layer5.rs`** — Red Gate (commit `7d1ca57`): 7 integration tests
+  covering the three two-filter AND combinations (status+priority,
+  status+label, priority+label), the three-way AND, the two-filter no-match
+  filter-message branch, the three-filter no-match filter-message branch,
+  and the default-view-non-empty no-filter-message branch. All seven are
+  Cat B Red Gate deviations (the AND-combination was emergent from prior
+  layers' chained retains; the integration tests are regression coverage
+  of acceptance criteria, not Red Gate gating for new behavior — same
+  disposition as Layer 3's `create_without_priority_defaults_to_medium`
+  and Layer 4's two Cat B deviations).
+- **`TODO.md`** — Layer 5 acceptance-criteria checkboxes flipped to `[x]`
+  (commit `bd15a9d`); manual-testing checklist flipped after human
+  verification (commit `da0fd8d`); manual-testing setup wording amended in
+  Round 2 (commit `7f9bae4`) per SO Review 18 Finding 3 to enumerate the
+  `tracker create` invocations and the `tracker status 3 done` step
+  required to produce the `(done, high, bug)` issue.
+- **`src/lib.rs`** (`cmd_list` comment) Round 2 — replaced the anticipatory
+  `--description-contains` example with neutral "any new filter the spec is
+  amended to add" framing plus a DESIGN.md "Out of Scope" citation, per SO
+  Review 18 Finding 1 (DESIGN.md excludes text-search filtering).
+- **`tests/layer5.rs`** (`list_priority_and_label_filter_and_combination`
+  docstring) Round 2 — trimmed false claim that one of the setup issues is
+  in-progress (per SO Review 18 Finding 2). Test assertions unchanged.
+
+### IAR
+
+Layer 5 Round 1 cold-batch — 5 domain reviews (SO 18; SA 11; QE 13; SE 13;
+VDD-IAR 13). Verdict: 5 substantive Low Open findings + 1 Medium-severity
+carry-forward (SA R11 F1, rendering half of `cmd_list` extraction —
+deferred to focused pre-Layer-7 PR per prior SA R10 disposition). Round 2
+warm-resolution closure pass — 4 domain reviews (SO 19; SA 12; QE 14;
+SE 14) + VDD-IAR 14 merge-gate verdict: GO. The 5 substantive findings
+closed inline in commit `7f9bae4`; the 1 carry-forward holds named-future-
+layer disposition. MVR reached.
+
+### Verification
+
+- `cargo test --locked --no-fail-fast` — **136/136 pass** at gate close
+  (45 unit + 32 layer1 + 18 layer2 + 9 layer3 + 25 layer4 + 7 layer5).
+- `cargo clippy --all-targets --locked -- -D warnings` — clean.
+- `cargo fmt --check` — clean.
+- Manual testing checklist (TODO.md Layer 5) — six items executed by the
+  director; all six expected outputs reproduced.
+
+---
+
 ## Layer 4 IAR Round 2 closure — 2026-05-06 02:30Z
 
 **Scope:** Resolves the Open finding cluster surfaced by Layer 4 Round 1

--- a/issue-tracker-cli/PROCESS.md
+++ b/issue-tracker-cli/PROCESS.md
@@ -339,3 +339,59 @@ The obvious thing I got wrong was using a lower capability model (Sonnet 4.6) fo
 *[First-person reflection on Layer 4. Possible threads: the cold-batch finally working as designed (Round 1 produced substantial real findings; Round 2 verified the fixes — the prediction in the suite README that "parallel independent sessions are the gold standard" was empirically borne out); the Round-1 → Round-2 cadence as the first full-cycle execution of CLOSURE-PROTOCOL.md Section 5; the way writing this retrospective itself drove a suite-level change (the meta-leak incident from Layer 1 became Suite Review 36 because the Layer 4 closure work surfaced it); the experience of orchestrating 11 parallel subagents and then 10 Round-2 entries vs. the same-session batches of prior layers.]*
 
 Opus 4.7 yielded a much more set it and forget it vibe for Layer 4. It worked great and revealed a lot of findings. I won't know for a few more layers if that was a model deficiency or a cold-batch one. I liked playing with the CLOSURE-PROTOCOL and it has some good ideas but I don't think this will be it's final form. It will however be used as context for a future development sprint of my VSDD suite
+
+---
+
+## Layer 5: Compound filtering
+
+### Phases
+
+**Decomposition**
+
+DESIGN.md Feature 2 already specified the AND-combination of `--status`, `--priority`, and `--label` filters (line 63) and the no-match filter-message branch (line 71). TODO.md Layer 5 was filled with 8 acceptance criteria, 6 manual testing checklist items, and a Red Gate plan of 4 integration tests + 2 unit tests. What was *not* fully foreseen at decomposition time: the AND-combination behavior was already emergent from the chained `retain()` calls in `cmd_list` (Layer 3 added the priority retain, Layer 4 added the label retain). Layer 5 had no new externally observable behavior to ship — the work was instead to extract a named pure predicate so the AND-logic could be unit-tested in isolation, and to add explicit AC-coverage tests (which would necessarily be Cat B Red Gate deviations because they passed against the existing implementation).
+
+**Red Gate (commit `7d1ca57`)**
+
+7 integration tests in `tests/layer5.rs` and 5 unit tests in `src/lib.rs`'s `mod tests`, with `issue_matches_filters` introduced as a `todo!()` stub. Confirmed Red: 5 unit-test panics from `todo!()` (Cat A — the genuine Red Gate for Layer 5), 7 integration-test passes (Cat B Red Gate deviations explicitly disclosed in the test-file header comment and in the commit message). The Phase-2a-only `#[allow(dead_code)]` annotation on the stub was the strongest single artifact that the Red Gate was real and not performative — `cmd_list` did not yet call the predicate, so the lib build needed the allow to satisfy `-D warnings`; Phase 2b removed it.
+
+**Implementation (commit `bd15a9d`)**
+
+Replaced the `todo!()` body with `issue.status == status && priority.is_none_or(|p| issue.priority == p) && label.is_none_or(|l| label_matches(&i.labels, l))`, refactored `cmd_list`'s three chained `retain()` calls into one `retain()` over the predicate, removed the `#[allow(dead_code)]`. 1 minute 28 seconds after the Red Gate commit. Net change: −5 lines in `src/lib.rs`. All five Layer-5 unit tests flipped from panic to pass; all seven integration tests remained green; no prior-layer regressions.
+
+**Manual testing (commit `da0fd8d`)**
+
+Director executed all six Layer 5 manual checklist items and signed off. The setup wording was tighter than Layers 2-4 (it elided the explicit `tracker status 3 done` step required to produce the `(done, high, bug)` issue) — a drift from the prior layers' explicitness norm that the Round-1 IAR caught.
+
+**Round 1 IAR — cold-session parallel batch**
+
+Five domain reviews dispatched in a single message via 5 fresh subagents (orchestrator coordinated dispatch but did not author any review). Domain set: SO 18, SA 11, QE 13, SE 13, VDD-IAR 13. Active-domain set was narrower than Layer 4's 11 because Layer 5 introduced no new attack surface (no new I/O, no new free-form text field, no new clap arg) — Security, Red Team, UX, Platform Engineer, Data Engineer, Technical Writer were not part of Layer 5's IAR plan per `TODO.md:275`.
+
+Findings:
+
+- **SO Review 18** — 3 Low Open. F1: anticipatory `--description-contains` comment in `cmd_list` named a feature DESIGN.md "Out of Scope" excludes (text search). F2: `list_priority_and_label_filter_and_combination` test docstring claimed an in-progress setup issue that does not exist in the test setup. F3: manual checklist setup wording elided the `tracker status 3 done` step required to produce the `(done, high, bug)` issue (drift from Layers 2-4 explicitness).
+- **SA Review 11** — 1 Open Medium (carry-forward, deferred), 2 Resolved, 2 Dismissed, 1 Hallucinated. F1 Open: rendering half of `cmd_list` extraction (column-width literals × 4 sites, no `format_*_row` helpers) — explicitly framed as "filter half closed by Layer 5; rendering half remains, deferred to focused pre-Layer-7 PR per SA R10 disposition." Resolved: filter-half of SA R9 F1; `extra_filter_active` disjunction property survives Layer 5.
+- **QE Review 13** — 1 Low Open, 1 carried-forward Resolved. F1: defense-in-depth — the inter-conjunct `&&`→`||` mutation between the priority and label optionals survives all 5 Round-1 unit tests (each single-mismatch subcase short-circuits true on the matching conjunct under `||`); caught at integration but not at unit. Carried-forward: QE R11 F5 (compound-filter test deferred to Layer 5) closes via `list_three_filter_and_combination`.
+- **SE Review 13** — 1 Low Open, 3 Dismissed. F1: `issue_matches_filters` rustdoc qualified the priority/status caller-normalization contract but left the label side ambiguous; a future second predicate caller could miss the trim-symmetry obligation and reintroduce the UX R6 F1 / DE R7 F2 / SO R16 F2 / SE R12 F4 bug class.
+- **VDD-IAR Review 13** — 0 Open. All 8 process dimensions Clean. Phase 2a/2b boundary verified real (not performative) via the `#[allow(dead_code)]` add/remove pattern. Cat B Red Gate disposition audited honest. Merge-gate verdict: GO on Phase-2 process compliance.
+
+**Round 2 IAR — warm-resolution + warm-verification (commits `7f9bae4`, `3139a2d`)**
+
+Commit `7f9bae4` bundled all five inline closures: SO F1 (comment edit), SO F2 (test docstring trim), SO F3 (TODO.md setup wording), QE F1 (`filter_and_logic_is_not_or_between_optional_conjuncts` defense unit test), SE F1 (rustdoc trim-normalization caller obligation). Test count 135 → 136. Commit `3139a2d` appended Round-2 closure entries: SO 19, SA 12, QE 14, SE 14, VDD-IAR 14. The single Open finding (SA R11 F1) holds named-future-layer disposition (focused pre-Layer-7 PR).
+
+**Gate closure**
+
+VDD-IAR Review 14 verdict: **GO.** All five `README.md` § Merging gate criteria satisfied: domain pass complete, MVR reached, every finding terminal (5 Resolved, 1 Deferred-with-named-layer), VDD-IAR ran as the final gate step, round numbers logged. Layer 5 cleared to merge.
+
+---
+
+### What was hardest
+
+*[First-person reflection on Layer 5. Possible threads: Layer 5 had no new externally observable behavior — the AND-combination was already emergent from prior layers' chained retains, so the entire Red Gate was a refactor-to-testability move plus AC-coverage tests that necessarily passed Cat B; the question of whether a layer that ships only an internal abstraction is "really" a layer in the VSDD sense; the Round 1 finding count (5 substantive Low + 1 carry-forward) being substantially smaller than Layer 4's 23 — was that because Layer 5 was genuinely smaller, because the active-domain set was narrower, or because the Round-1 cold-batch primer had matured by Layer 5; the experience of writing the Phase-2a-only `#[allow(dead_code)]` annotation as a deliberate Red-Gate-integrity artifact, knowing it would later be the proof that Phase 2a was real.]*
+
+### What I got wrong
+
+*[First-person reflection on Layer 5. Possible threads: the manual testing checklist wording (TODO.md:256) drifted from the explicitness norm of Layers 2-4 — caught by SO Review 18 F3 only because the cold-session reviewer compared it to prior layers; the anticipatory `--description-contains` comment in `cmd_list` (predates Layer 5 but Layer 5's commit message ratified the same direction) — anticipatory creep at the comment level is a recurring class of finding the cold-batch is good at catching; the rustdoc on `issue_matches_filters` did not document the label-side caller obligation explicitly, exactly the doc gap class that has bitten the project before (the trim-symmetry contract was broken once already at Layer 4).]*
+
+### What the process felt like
+
+*[First-person reflection on Layer 5. Possible threads: the second consecutive cold-batch run (Layer 4 was the first), and whether the cadence felt rehearsed or still novel; the size asymmetry between Layer 4's 11-domain run and Layer 5's 5-domain run — did the smaller domain set feel proportional to Layer 5's smaller surface, or did it feel under-reviewed; the Round-2 closure pass landing in two commits (one for inline fixes, one for review log entries) versus Layer 4's similar split — does this two-commit shape feel right for the closure cadence; the way the entire Layer 5 work — design, Red Gate, implementation, manual testing, IAR Round 1, IAR Round 2, gate closure — landed within a single working session, versus Layer 4's multi-day arc.]*

--- a/issue-tracker-cli/PROCESS.md
+++ b/issue-tracker-cli/PROCESS.md
@@ -388,10 +388,16 @@ VDD-IAR Review 14 verdict: **GO.** All five `README.md` § Merging gate criteria
 
 *[First-person reflection on Layer 5. Possible threads: Layer 5 had no new externally observable behavior — the AND-combination was already emergent from prior layers' chained retains, so the entire Red Gate was a refactor-to-testability move plus AC-coverage tests that necessarily passed Cat B; the question of whether a layer that ships only an internal abstraction is "really" a layer in the VSDD sense; the Round 1 finding count (5 substantive Low + 1 carry-forward) being substantially smaller than Layer 4's 23 — was that because Layer 5 was genuinely smaller, because the active-domain set was narrower, or because the Round-1 cold-batch primer had matured by Layer 5; the experience of writing the Phase-2a-only `#[allow(dead_code)]` annotation as a deliberate Red-Gate-integrity artifact, knowing it would later be the proof that Phase 2a was real.]*
 
+Nothing particularly hard. More on that below.
+
 ### What I got wrong
 
 *[First-person reflection on Layer 5. Possible threads: the manual testing checklist wording (TODO.md:256) drifted from the explicitness norm of Layers 2-4 — caught by SO Review 18 F3 only because the cold-session reviewer compared it to prior layers; the anticipatory `--description-contains` comment in `cmd_list` (predates Layer 5 but Layer 5's commit message ratified the same direction) — anticipatory creep at the comment level is a recurring class of finding the cold-batch is good at catching; the rustdoc on `issue_matches_filters` did not document the label-side caller obligation explicitly, exactly the doc gap class that has bitten the project before (the trim-symmetry contract was broken once already at Layer 4).]*
 
+I do want to take another consistency pass at manual testing. The manual tests in the TODO and the PR do not match. Who owns the manual test plan? Does it get modified in response to findings in review? Should it be spun off into a separate .md file like it will be handed off and worked by a 3rd party reviewer--that's what my previous test plan decomp edits were pointing towards but they were not applied retroactively here.
+
 ### What the process felt like
 
 *[First-person reflection on Layer 5. Possible threads: the second consecutive cold-batch run (Layer 4 was the first), and whether the cadence felt rehearsed or still novel; the size asymmetry between Layer 4's 11-domain run and Layer 5's 5-domain run — did the smaller domain set feel proportional to Layer 5's smaller surface, or did it feel under-reviewed; the Round-2 closure pass landing in two commits (one for inline fixes, one for review log entries) versus Layer 4's similar split — does this two-commit shape feel right for the closure cadence; the way the entire Layer 5 work — design, Red Gate, implementation, manual testing, IAR Round 1, IAR Round 2, gate closure — landed within a single working session, versus Layer 4's multi-day arc.]*
+
+This layer felt too easy. I could have easily done it one shot. That requires a bit of interrogation about whether it's skill with the method improving, a discipline problem with the process, or just that this layer was correctly scoped.

--- a/issue-tracker-cli/TODO.md
+++ b/issue-tracker-cli/TODO.md
@@ -253,12 +253,12 @@ Unit tests:
 **Not in this layer:** any new commands or flags
 
 **Manual Testing Checklist:**
-- [ ] Setup: create four issues — `(open, high, bug)`, `(open, medium, bug)`, `(done, high, bug)`, `(open, high, feature)` — then run each filter combination and verify only the correct issue(s) appear
-- [ ] Two-filter AND: `--status open --priority high` → issues #1 and #4 only
-- [ ] Three-filter AND: `--status open --priority high --label bug` → issue #1 only
-- [ ] No-match from filters: `--status open --priority low` → `No issues match the given filters.`
-- [ ] Default view (open exists): `tracker list` → shows open issues, not the no-match message
-- [ ] `No open issues. Nice work!` message: mark all issues done, `tracker list` → correct empty-state message (not the filter message)
+- [x] Setup: create four issues — `(open, high, bug)`, `(open, medium, bug)`, `(done, high, bug)`, `(open, high, feature)` — then run each filter combination and verify only the correct issue(s) appear
+- [x] Two-filter AND: `--status open --priority high` → issues #1 and #4 only
+- [x] Three-filter AND: `--status open --priority high --label bug` → issue #1 only
+- [x] No-match from filters: `--status open --priority low` → `No issues match the given filters.`
+- [x] Default view (open exists): `tracker list` → shows open issues, not the no-match message
+- [x] `No open issues. Nice work!` message: mark all issues done, `tracker list` → correct empty-state message (not the filter message)
 
 **Red Gate — tests to write first:**
 

--- a/issue-tracker-cli/TODO.md
+++ b/issue-tracker-cli/TODO.md
@@ -241,14 +241,14 @@ Unit tests:
 **Goal:** Status, priority, and label filters AND-combine correctly; all no-match states are correct.
 
 **Acceptance Criteria:**
-- [ ] `tracker list --status open --priority high` shows only issues that are both open AND high-priority
-- [ ] `tracker list --status open --label bug` shows only open issues with label `bug`
-- [ ] `tracker list --priority high --label bug` shows only high-priority issues with label `bug`
-- [ ] `tracker list --status open --priority high --label bug` shows only issues matching all three
-- [ ] An issue that matches two of three filters but not the third does NOT appear
-- [ ] `tracker list --status done --priority low` with no matching issues prints `No issues match the given filters.`
-- [ ] `tracker list --status open --priority high --label nonexistent` with no matching issues prints `No issues match the given filters.`
-- [ ] `tracker list` (default, all open, some exist) shows only open issues, not `No issues match` message
+- [x] `tracker list --status open --priority high` shows only issues that are both open AND high-priority
+- [x] `tracker list --status open --label bug` shows only open issues with label `bug`
+- [x] `tracker list --priority high --label bug` shows only high-priority issues with label `bug`
+- [x] `tracker list --status open --priority high --label bug` shows only issues matching all three
+- [x] An issue that matches two of three filters but not the third does NOT appear
+- [x] `tracker list --status done --priority low` with no matching issues prints `No issues match the given filters.`
+- [x] `tracker list --status open --priority high --label nonexistent` with no matching issues prints `No issues match the given filters.`
+- [x] `tracker list` (default, all open, some exist) shows only open issues, not `No issues match` message
 
 **Not in this layer:** any new commands or flags
 

--- a/issue-tracker-cli/TODO.md
+++ b/issue-tracker-cli/TODO.md
@@ -253,7 +253,7 @@ Unit tests:
 **Not in this layer:** any new commands or flags
 
 **Manual Testing Checklist:**
-- [x] Setup: create four issues — `(open, high, bug)`, `(open, medium, bug)`, `(done, high, bug)`, `(open, high, feature)` — then run each filter combination and verify only the correct issue(s) appear
+- [x] Setup: run `tracker create "..." --priority high --label bug`, `tracker create "..." --priority medium --label bug`, `tracker create "..." --priority high --label bug` then `tracker status 3 done`, `tracker create "..." --priority high --label feature` — produces issues `(open, high, bug)`, `(open, medium, bug)`, `(done, high, bug)`, `(open, high, feature)`. Then run each filter combination and verify only the correct issue(s) appear.
 - [x] Two-filter AND: `--status open --priority high` → issues #1 and #4 only
 - [x] Three-filter AND: `--status open --priority high --label bug` → issue #1 only
 - [x] No-match from filters: `--status open --priority low` → `No issues match the given filters.`

--- a/issue-tracker-cli/iterative-adversarial-refinement/QUALITY-ENGINEER-REVIEW.md
+++ b/issue-tracker-cli/iterative-adversarial-refinement/QUALITY-ENGINEER-REVIEW.md
@@ -1167,3 +1167,216 @@ Unchanged. The Layer 5 Red Gate must include the test or this deferral has slipp
 - `src/lib.rs#tests` — +11 unit tests.
 
 ---
+
+## Review 13 — 2026-05-07 00:24Z
+
+**Round:** QE Review 13 (Layer 5 — Compound Filtering)
+**Scope:** Layer 5 lands on the `issue-tracker-cli-compound-filtering` branch in three commits — `7d1ca57` (Phase 2a Red Gate: 7 integration tests + 5 unit tests + `issue_matches_filters` `todo!()` stub), `bd15a9d` (Phase 2b: predicate body + `cmd_list` collapses three `retain` calls into one), `da0fd8d` (manual testing checklist completion). Files read: `DESIGN.md`, `TODO.md` lines 239-275, `tests/layer5.rs`, `tests/layer{1,2,3,4}.rs`, `src/lib.rs` Layer 5 surface (`issue_matches_filters` + refactored `cmd_list`), `src/lib.rs#tests` Layer 5 block (lines 851-948), prior QE Reviews 10/11/12 for prior-finding context. Full-suite verification: `cargo test --no-fail-fast --locked` → **135 passed / 0 failed** (49 unit + 32 layer1 + 18 layer2 + 9 layer3 + 25 layer4 + **7 layer5**). Pre-review state: 135 passed. Net delta from this review: 0 source/test changes (no findings warrant inline resolution; see Open / Dismissed / Hallucinated below).
+
+**Session note:** Cold session, parallel batch with SO Review 18 / SA Review 11 / SE Review 13 / VDD-IAR Review 13. No prior participation in Layer 5 implementation, Red Gate authoring, or in-session reviews. Carried-forward marker from Review 12: Open Finding 5 ("Compound-filter test deferred to Layer 5") closes via Layer 5's Red Gate inclusion of `list_three_filter_and_combination`; the deferral was honored (see AC mapping below).
+
+**Red Gate verdict (Layer 5):** Compliant. The Red Gate commit `7d1ca57` introduced (a) 7 integration tests in `tests/layer5.rs` explicitly self-classified as "Cat B Red Gate deviations" — the AND-combination is an emergent property of Layers 3-4's chained `retain()` calls, so the integration tests pass against the unrefactored implementation as regression coverage; (b) 5 unit tests against an `issue_matches_filters` `todo!()` stub that genuinely panic at Red Gate time. The Phase-2a-only `#[allow(dead_code)]` on the stub is honest about why the predicate is not yet wired into `cmd_list`. Implementation commit `bd15a9d` replaces the stub body with the AND predicate and collapses the three chained `retain` calls into one over the predicate, preserving observable behavior. The Cat B classification is itself adversarially honest — see Dim 2 audit below.
+
+**Assumption surfacing:** `Option::is_none_or` (stable since Rust 1.82, present in this MSRV per `Cargo.toml`), `predicate::str::contains(...).not()` chaining, `assert_cmd::Command::cargo_bin`, `tempfile::TempDir` all verified against the lockfile. No hallucinated APIs in new test or source code.
+
+### Layer 5 acceptance criteria → test trace
+
+| AC (TODO.md lines 244-251) | Test(s) | Category |
+|---|---|---|
+| AC 1 — `--status open --priority high` shows only matching | `list_status_and_priority_filter_and_combination` | Cat B integration |
+| AC 2 — `--status open --label bug` shows only matching | `list_status_and_label_filter_and_combination` | Cat B integration |
+| AC 3 — `--priority high --label bug` shows only matching | `list_priority_and_label_filter_and_combination` | Cat B integration |
+| AC 4 — `--status open --priority high --label bug` (three-filter AND) | `list_three_filter_and_combination` (also closes QE R11/R12 carried-forward Open Finding 5) | Cat B integration |
+| AC 5 — 2/3 match but not 3rd → does NOT appear | `list_three_filter_and_combination` (three subcase `!contains` assertions) + unit `filter_and_logic_all_must_match` (three predicate-level subcases) | Cat B + Cat A unit |
+| AC 6 — `--status done --priority low` no match → filter message | `list_compound_two_filter_no_match_shows_filter_message` | Cat B integration |
+| AC 7 — `--status open --priority high --label nonexistent` no match → filter message | `list_compound_three_filter_no_match_shows_filter_message` | Cat B integration |
+| AC 8 — `tracker list` (default, open issues exist) shows them, NOT filter message | `list_default_view_with_open_issues_does_not_show_filter_message` | Cat B integration |
+
+**Predicate-level Cat A unit tests (5):** `filter_and_logic_all_present_returns_true` (true case), `filter_and_logic_all_must_match` (three 2/3-mismatch subcases — status-only-fails, priority-only-fails, label-only-fails), `filter_status_only_matches_any_priority_and_labels` (None=wildcard for priority + label), `filter_status_mismatch_rejects_regardless_of_optional_filters` (status is required), `filter_label_match_is_case_sensitive` (case-sensitivity preserved through the predicate boundary).
+
+**Coverage verdict: 8/8 ACs traced to at least one passing automated test that fails if the AC is violated.**
+
+### Mutation analysis — `issue_matches_filters`
+
+The predicate body is:
+
+```rust
+issue.status == status
+    && priority.is_none_or(|p| issue.priority == p)
+    && label.is_none_or(|l| label_matches(&issue.labels, l))
+```
+
+For each unit test, one mutation killed and one not killed:
+
+| Unit test | Mutation killed | Mutation NOT killed (gap or covered elsewhere) |
+|---|---|---|
+| `filter_and_logic_all_present_returns_true` | constant-`false` body | swap `==` → `!=` on status alone (would surface only via the all-must-match test); covered by `filter_and_logic_all_must_match` and `filter_status_mismatch_rejects_regardless_of_optional_filters` |
+| `filter_and_logic_all_must_match` | drop any single conjunct (replace with `true`) — three subcases pin the three conjuncts independently | swap `&&` → `\|\|` between the first two AND'd terms when neither short-circuits to false on its own (e.g., status-mismatch + priority-mismatch with label-match); not exercised — see Open Finding 1 |
+| `filter_status_only_matches_any_priority_and_labels` | swap `is_none_or` → `is_some_and` (None branch becomes false) | a mutation that always returns `true` when both optional filters are `None` regardless of status; covered by `filter_status_mismatch_rejects_regardless_of_optional_filters` (this test alone wouldn't catch it) |
+| `filter_status_mismatch_rejects_regardless_of_optional_filters` | route status to `!=` | a mutation that ignores `issue.status` and uses `priority.unwrap_or("open") == status` instead — covered transitively by `filter_and_logic_all_must_match` priority subcase |
+| `filter_label_match_is_case_sensitive` | inserting `.to_lowercase()` on either side of `label_matches`'s `==` | a mutation that swaps the compare to `labels.iter().all(\|l\| l == filter)` instead of `.any(...)` — predicate-level NOT caught here (test issue has only one label so `any` and `all` agree); covered at integration via Layer 4 `list_label_filter_shows_matching` "No-label item" subcase, which would surface a vacuous-`all`-true (an unlabeled issue would appear under `--label bug`) |
+
+**Aggregate mutation score:** All five "drop-a-conjunct" mutations are killed. All three "single-clause inversion" mutations (status `==`→`!=`, priority `==`→`!=`, label predicate inversion) are killed. The case-sensitivity contract is killed by `filter_label_match_is_case_sensitive`. The optional-filter wildcard contract is killed by `filter_status_only_matches_any_priority_and_labels`. The required-status-filter contract is killed by `filter_status_mismatch_rejects_regardless_of_optional_filters`. **Predicate-level coverage is tight.**
+
+### Open
+
+**Finding 1 — `&&` → `||` mutation between status and priority conjuncts is not caught at the predicate level when only one disjunct fires (Dim 3 — Mutation resilience)**
+
+The predicate is `issue.status == status && priority.is_none_or(...) && label.is_none_or(...)`. Consider the mutation `&&` → `||` between the **first two** conjuncts: `issue.status == status || priority.is_none_or(...) && label.is_none_or(...)`. Rust precedence binds `&&` tighter than `||`, so this parses as `status == status || (priority.is_none_or(...) && label.is_none_or(...))`.
+
+- `filter_and_logic_all_must_match` status-mismatch subcase: `issue=("open","high",["bug"])`, call `(issue, "done", Some("high"), Some("bug"))`. Mutated predicate: `false || (true && true)` = **true**. Expected: false. **Caught.**
+- `filter_and_logic_all_must_match` priority-mismatch subcase: call `(issue, "open", Some("low"), Some("bug"))`. Mutated predicate: `true || (false && true)` = **true**. Expected: false. The original predicate also returns false. **NOT caught — survives.**
+- `filter_and_logic_all_must_match` label-mismatch subcase: `(issue, "open", Some("high"), Some("feature"))`. Mutated: `true || (true && false)` = **true**. Original: false. **NOT caught — survives.**
+
+So the status-subcase catches the `&&`→`||` mutation between conjuncts 1 and 2, but only because it's the only subcase where the LHS of the `||` is false. A symmetric mutation `&&` → `||` between conjuncts 2 and 3 (i.e., `status == status && (priority.is_none_or(...) || label.is_none_or(...))`) is **not caught by any unit test**: the priority-mismatch subcase yields `true && (false || true)` = true (expected false); label-mismatch subcase yields `true && (true || false)` = true (expected false). Both survive. The status-mismatch subcase yields `false && (...)` = false (expected false) — also survives.
+
+At integration level, `list_three_filter_and_combination` does cover this: each "wrong-X-only" subcase has a negative `!contains` assertion, and the implementation goes through the predicate, so the `&&`→`||` between conjuncts 2 and 3 mutation would surface "Wrong priority only" or "Wrong label only" in the output. Verified by mental execution: with the mutation, `issue.status == "open" && (priority.is_none_or(|p| p == "medium") || label.is_none_or(|l| label_matches(&["bug"], l)))` evaluated against the priority-mismatch issue ("Wrong priority only", priority=medium, labels=["bug"]) and filter `(open, high, bug)` becomes `true && (false || true)` = true. The issue would appear in output. The `!contains("Wrong priority only")` assertion fires. **Caught at integration.**
+
+**Severity: Low.** The mutation is killed at the integration boundary, just not at the predicate-unit boundary. The unit tests are slightly thinner than they appear: their AC-pinning value is real (each conjunct's role is demonstrated), but the structural argument that "five focused unit tests fully cover the predicate" overstates the case — the integration test is doing real work that the unit tests do not.
+
+**Evidence:** `src/lib.rs:425-434` (predicate); `src/lib.rs#tests:880-901` (`filter_and_logic_all_must_match`); `tests/layer5.rs:185-279` (`list_three_filter_and_combination`).
+
+**Rationale:** Defense-in-depth at the predicate boundary is cheap. A single additional unit subcase — e.g., `filter_or_logic_between_optional_conjuncts_is_not_a_substitute` asserting `!issue_matches_filters(&issue_with("open","medium",["bug"]), "open", Some("high"), Some("feature"))` — would kill the `&&`→`||`-between-conjuncts-2-and-3 mutation at the unit level. It's slightly redundant with the integration test, but the cost is one assertion line.
+
+**Classification: Open / Low severity / non-blocking.** This is a sharper-than-required mutation analysis; the integration test catches the mutation. Recommend addition as a defense-in-depth strengthening, not a merge-gate concern.
+
+**Proposed action:** Add to `mod tests` in `src/lib.rs`:
+```rust
+#[test]
+fn filter_and_logic_is_not_or_between_optional_conjuncts() {
+    // Defense-in-depth against `&&` → `||` between the priority and label
+    // conjuncts: an issue that mismatches BOTH optional filters (matching
+    // status only) must still reject. Catches a mutation that the three
+    // single-mismatch subcases of filter_and_logic_all_must_match do not.
+    let issue = issue_with("open", "medium", &["bug"]);
+    assert!(!issue_matches_filters(&issue, "open", Some("high"), Some("feature")));
+}
+```
+
+---
+
+### Dismissed
+
+**Finding 2 — Cat B classification of the 7 integration tests is "honest sycophancy" — could the dev have made them Cat A by extracting the predicate before Layer 3/4? (Dim 2 — Red Gate compliance)**
+
+Adversarial probe: the Red Gate commit message says "the AND-combination is an emergent property of cmd_list's chained retain() calls (Layer 3 added --priority retain, Layer 4 added --label retain), so the CLI behavior was implemented incrementally rather than as a single Layer 5 change." Could the dev have written these as Cat A by sequencing differently — e.g., introducing `issue_matches_filters` at Layer 3 with priority-only support, then extending in Layer 4, then asserting AND-combination as the Layer 5 Red Gate?
+
+**Classification: Dismissed.** The actual decomposition followed the layer plan in `TODO.md` (line 270 explicitly enumerates `filter_and_logic_all_must_match` as the Layer 5 unit Red Gate, not the integration tests). The integration tests for AC 1-3 (two-filter AND combinations) genuinely could not be Cat A under the layer plan — once Layer 3 added `--priority` filtering and Layer 4 added `--label` filtering with chained `retain` calls, the two-filter AND was *already implemented*. The Cat B classification accurately describes regression coverage of pre-existing emergent behavior. The same disposition applied at Layer 3 (`create_without_priority_defaults_to_medium` was Cat B because Layer 1 already defaulted via `priority: "medium"`) and Layer 4 (two Cat B deviations on Layer 1 defaults). The pattern is honest, consistent, and correctly self-classified.
+
+The only path to genuinely Cat A integration tests at Layer 5 would have been to *not* implement the per-filter `retain` calls at Layers 3 and 4, deferring all filtering until a single Layer 5 implementation. That contradicts the layer plan's per-flag layering. **No finding.**
+
+---
+
+**Finding 3 — `list_default_view_with_open_issues_does_not_show_filter_message` exit-status assertion absent (Dim 3 — Assertion strength)**
+
+The test calls `.assert().success()` then extracts stdout/stderr separately for content checks. `success()` already asserts exit code 0; no separate `.code(0)` is needed. Other Layer 5 tests follow the same pattern and use `success()`.
+
+**Classification: Dismissed.** `assert_cmd::Assert::success()` is documented to assert `code == 0` per its Rust docs; this is the canonical idiom in the rest of the suite (see Layer 1/2/3/4). Adding a redundant `.code(0)` would be cargo-cult. No finding.
+
+---
+
+**Finding 4 — AC 6 ("`--status done --priority low` no match") setup uses one open-high and one open-low issue; neither has `--status done`. Could a mutation still surface? (Dim 5 — Empty-state coverage)**
+
+`list_compound_two_filter_no_match_shows_filter_message` creates two issues — `(open, high)` and `(open, low)` — then filters `--status done --priority low`. Neither matches both. The test asserts the filter message appears and `Nice work!` does not. The negative `Nice work!` assertion is the structural defense (per QE Review 9 Finding 1 / Review 11 Finding 3 pattern), and it is present.
+
+But: is the setup adversarial enough? An issue that's `(done, low)` would match. A mutation that broke the filter would surface either issue. The test would detect both. **Dismissed — the setup is correct.** The negative `Nice work!` assertion specifically guards against the SO Review 11 hazard where adding a new filter and forgetting to extend `extra_filter_active` routes the empty-state path back to "Nice work!" — and `list_compound_two_filter_no_match_shows_filter_message`'s `effective_status == "done"` setup means `is_default_open_view` is false regardless of the disjunction — so this test is somewhat weaker than `list_compound_three_filter_no_match_shows_filter_message` for that specific hazard. The three-filter sibling closes the gap (its `effective_status == "open"` setup makes `is_default_open_view` route on the disjunction).
+
+**Classification: Dismissed.** The two tests are complementary — between them, both branches of `is_default_open_view` are exercised in compound contexts. No new finding.
+
+---
+
+**Finding 5 — Cat B integration test assertions use substring `contains` rather than full-line matching for issue rendering (Dim 3)**
+
+E.g., `list_three_filter_and_combination` asserts `out.contains("Triple match")` — a substring match. A mutation that printed only `Triple match` with no other column data would still pass this assertion.
+
+**Classification: Dismissed.** Layer 1's `list_shows_header_and_issues` and Layer 3's `list_columns_use_exactly_two_space_separator` already pin the column-rendering contract. Layer 5's tests are correctly scoped to filter selection (which titles appear / don't appear), not column formatting. Conflating two contracts in a single test is the anti-pattern QE Review 11 Finding 6 explicitly dismissed at Layer 4. Same disposition here.
+
+---
+
+**Finding 6 — No Layer 5 test for `list --priority X --label Y` with `--status` defaulting to `"open"` AND only `done` issues exist (Dim 5 — Empty-state path interaction)**
+
+Adversarial probe: when `--priority` and `--label` are both supplied but `--status` is not, `effective_status = "open"`, `extra_filter_active = true`, so `is_default_open_view = false`. If all stored issues are `done`, the result is empty and the filter-message branch fires. Is this covered?
+
+`list_priority_and_label_filter_and_combination` does have an in-progress issue intended to confirm the implicit-status-default filter, BUT the test asserts a **non-empty** result ("Match all" appears), not an empty one. So the empty-result-with-implicit-default path is not directly asserted at Layer 5.
+
+**Classification: Dismissed.** The path is exercised transitively by `list_compound_two_filter_no_match_shows_filter_message` (effective_status="done", priority="low") and `list_compound_three_filter_no_match_shows_filter_message` (effective_status="open" via `--status open`, priority="high", label="nonexistent"). The latter exercises the `extra_filter_active = true && effective_status == "open"` routing precisely. The implicit-default vs. explicit-`--status open` distinction is parser-side and identical past `parse_status` (both produce `effective_status == "open"`). Adding a third empty-state test for "implicit `--status open` + non-default filters + no match" would be tautological with the explicit form. No finding.
+
+---
+
+**Finding 7 — Manual testing checklist relies on developer attestation; no automated verification of the four-issue setup or two-filter / three-filter outputs (Dim 7)**
+
+TODO.md lines 256-261 list 6 manual checks, all marked complete in commit `da0fd8d`. The integration tests in `tests/layer5.rs` cover all 6 automated equivalents (the four-issue setup matches `list_three_filter_and_combination`'s setup; the empty-state messages match the two compound-no-match tests; the default-view non-empty case matches the eighth test). The manual checklist is reproducible from TODO.md alone.
+
+**Classification: Dismissed.** Each manual check has an automated counterpart with stronger assertions (negative `!contains` for non-matching issues, exact stderr literal for empty-state messages). The dev's claim of completion is reproducible by anyone running `cargo test --test layer5` against the same source. No finding.
+
+---
+
+### Hallucinated
+
+**Finding 8 — `cmd_list` refactor changed evaluation order from three-pass `retain` to single-pass `retain`; could a mutation in the now-fused predicate body silently change short-circuit semantics? (Dim 6 — Regression coverage)**
+
+Concern: previously each `retain` call walked the full vector once; the refactor walks once and short-circuits on the first false. A side-effecting mutation in any conjunct would behave differently across the two forms.
+
+**Classification: Hallucinated.** No conjunct has side effects — `==` on `String`, `Option::is_none_or`, and `label_matches` (slice scan) are all pure. AND is commutative and associative for booleans; the ordering between the three `retain` passes (which always saw the full surviving set after each) and the single fused predicate (which short-circuits per-element) is observably identical. The refactor preserves behavior. No finding.
+
+---
+
+**Finding 9 — The unit test `filter_status_only_matches_any_priority_and_labels` asserts both `high_with_bug` and `low_no_labels` match — the second is redundant**
+
+Concern: the test creates two issues but the predicate's behavior is element-by-element; one issue suffices to assert "None=wildcard."
+
+**Classification: Hallucinated.** The two issues exercise distinct shapes (high+labelled vs. low+unlabelled) — both should pass when filters are None, and the test catches a subtle mutation where `is_none_or` is replaced with a non-empty-labels constraint (which would reject `low_no_labels` but accept `high_with_bug`). The two cases are intentionally complementary, not redundant. No finding.
+
+---
+
+**Finding 10 — `list_three_filter_and_combination` does not assert that issue ordering in the (single-result) output is correct**
+
+Concern: the test asserts `Triple match` is present but doesn't verify it's at position 1 in the table.
+
+**Classification: Hallucinated.** With one matching result, ordering is degenerate (only one issue can be in any position). Sort ordering is contract-pinned by Layer 3's `list_sorts_high_before_medium_before_low` and `list_within_tier_sorted_by_id_ascending`, which exercise a multi-issue result set. Layer 5's tests are correctly scoped to filter selection. No finding.
+
+---
+
+### Summary
+
+**Test count:** 135/135 pass post-review (49 unit + 32 layer1 + 18 layer2 + 9 layer3 + 25 layer4 + 7 layer5). Pre-review: 135/135. Net delta: 0 inline source/test changes. One Open Low-severity strengthening proposed (Finding 1: `&&`→`||` between optional conjuncts at predicate level — caught at integration but not at unit; recommend a one-test addition).
+
+**AC coverage:** 8/8 Layer 5 ACs traced to passing automated tests. The carried-forward Open Finding 5 from QE Reviews 11 and 12 (compound-filter test deferred to Layer 5) **closes** via `list_three_filter_and_combination` — the deferral was honored; the Layer 5 Red Gate enumerated the test before merge.
+
+**Cat B disposition:** **Honest.** The 7 integration tests are correctly classified as Cat B Red Gate deviations: AND-combination was an emergent property of Layers 3-4's chained `retain()` calls. The 5 unit tests are correctly Cat A — they exercise `issue_matches_filters` directly and panicked against the `todo!()` stub at Phase 2a. Per-conjunct mutation pinning is tight at the predicate level for single-clause inversions and drop-a-conjunct mutations; the only gap is the cross-conjunct `&&`→`||` mutation at the predicate-unit boundary, which is caught at integration via `list_three_filter_and_combination`'s three negative-subcase assertions.
+
+**Mutation resilience:** Strong at integration boundary; tight at predicate-unit boundary with one identified gap. The five unit tests collectively kill all single-conjunct-drop mutations, all single-clause-inversion mutations, all `is_none_or` ↔ `is_some_and` mutations, and all `to_lowercase` injections in the label compare. The cross-conjunct `&&`→`||` mutation between conjuncts 2-and-3 survives at the unit level but dies at the integration level via the AC 5 negative assertions.
+
+**Top concern:** None merge-blocking. Finding 1 is a defense-in-depth strengthening at the unit level that the integration test already covers. Layer 5 ships with stronger test coverage than Layers 3 or 4 did at their respective merge gates: the Red Gate self-classification practice has matured (Cat A unit + Cat B integration + adversarial empty-state coverage with both `effective_status` branches exercised).
+
+**Sycophancy check:** Did I pass any dimension because I couldn't think of a counterexample? Re-audited Dim 2 (Cat B) and Dim 3 (mutation resilience). On Cat B: I considered alternative decompositions and confirmed the actual one was forced by the layer plan, not a convenient story. On mutation resilience: I deliberately constructed `&&`→`||` mutations between specific conjunct pairs and traced each through every unit test rather than pattern-matching to "looks tight." Found one survival (Finding 1), filed it Low-severity, did not soften. On AC coverage: I checked each AC has a *failing*-on-violation test, not just a passing one — `list_default_view_with_open_issues_does_not_show_filter_message`'s `!stderr.contains("No issues match")` assertion specifically catches the inverse, so AC 8 is genuinely covered, not just nominally. **No softening detected.**
+
+**Coordination:**
+- **SE:** Open Finding 1 proposes adding one unit test (`filter_and_logic_is_not_or_between_optional_conjuncts`). QE owns `tests/**` and `src/lib.rs#tests` per CLOSURE-PROTOCOL.md; this can land in QE's same-round closure if the round produces a follow-up commit. If not, deferred to next layer.
+- **SO / SA:** No spec or architecture concerns surfaced.
+- **VDD-IAR Alignment:** Carried-forward Open Finding 5 (QE R11/R12) closes via Layer 5 Red Gate inclusion of `list_three_filter_and_combination`. Layer 5 merge gate is unblocked from the QE side.
+- **PE:** Coverage tooling absence (Finding 8 from QE R10/R11) remains escalated; no new escalation.
+- **No new domain coordination required.**
+
+---
+
+## Review 14 — 2026-05-07 00:41Z
+
+**Round:** QE Review 14 (Round-2 closure for Layer 5)
+**Scope:** Verify QE R13 F1 (defense-in-depth unit test for `&&`→`||` between optional conjuncts) is resolved by commit `7f9bae4`. Warm closure-verification.
+
+### Round-1 finding closure
+
+- **F1 (predicate-unit `&&`→`||` mutation between priority and label conjuncts survives all 5 Layer-5 unit tests):** **Resolved.** `src/lib.rs` `mod tests` adds `filter_and_logic_is_not_or_between_optional_conjuncts` — issue `(open, medium, [bug])` filtered with `priority=Some("high"), label=Some("feature")` mismatches both optionals at once, killing the inter-conjunct `||` mutation. The three single-mismatch subcases of `filter_and_logic_all_must_match` did not catch this mutation (each mismatched only one filter, so `||` would short-circuit-true on the matching conjunct). Test count: 136/136 (was 135 + 1 new defense unit test). Verified `cargo test --no-fail-fast --locked` green.
+
+### Catalog of un-killed mutations remaining
+
+After the new test, predicate-unit mutation analysis shows the AND-logic is mutation-tight at the unit level for: drop-a-conjunct, single-conjunct-flip (`==` → `!=`), `is_none_or` ↔ `is_some_and`, `to_lowercase` injection, single inter-conjunct `&&` → `||`. The only mutations that survive predicate-unit are CLI-wiring mutations (e.g., `cmd_list` passing the wrong filter into the wrong slot), which integration tests in `tests/layer5.rs` cover.
+
+### Summary
+
+1/1 Round-1 QE finding Resolved. 0 new findings this round. Layer 5 QE-domain is closed at MVR for the predicate-unit boundary.
+
+**Coordination:** *(none — closure pass)*
+
+---

--- a/issue-tracker-cli/iterative-adversarial-refinement/SOFTWARE-ENGINEER-REVIEW.md
+++ b/issue-tracker-cli/iterative-adversarial-refinement/SOFTWARE-ENGINEER-REVIEW.md
@@ -1325,3 +1325,183 @@ Unchanged from Round 1. SA R9 F1 / SE R11 F2 still Open. Round 2 was scoped to s
 - `src/lib.rs` — `parse_label`, `label_is_valid` (new), `display_safe` (new), `issue_fields_are_valid` (extended for labels), `parse_priority` / `parse_status` / `parse_id` formatter sanitization, `cmd_list` filter validation. Plus 11 new unit tests under the `#[cfg(test)] mod tests` block.
 
 ---
+
+## Review 13 — 2026-05-07 00:24Z
+
+**Round:** SE Review 13 (Layer 5 — Compound Filtering)
+**Scope:** Three-commit Layer 5 landing on `issue-tracker-cli-compound-filtering`:
+- `7d1ca57` — Phase 2a Red Gate (compound-filter unit tests + `issue_matches_filters` `todo!()` stub)
+- `bd15a9d` — Phase 2b implementation (predicate body + `cmd_list` retain-collapse refactor)
+- `da0fd8d` — Manual Testing Checklist completion
+
+Code surface reviewed: `src/lib.rs:425-434` (new `issue_matches_filters`), `src/lib.rs:465-544` (refactored `cmd_list`), `src/lib.rs:851-930` (Layer 5 unit tests), `tests/layer5.rs` (7 integration tests), `src/main.rs` (no Layer 5 changes — wiring identical to Layer 4), `rust-toolchain.toml`, `DESIGN.md` Feature 2 (lines 51-83 / Edge Cases lines 316-322), `TODO.md:239-275`.
+
+**Session note:** Cold session per `prompts/review-session.md` primer; parallel-batch with SO Review 18 / SA Review 11 / QE Review 13 / VDD-IAR Review 13. Sycophancy guard applied: walked the `issue_matches_filters` truth table from first principles before reading the existing tests, to avoid the "passes-because-no-counterexample-came-to-mind" failure mode the primer warns against. Test/clippy state re-verified at session start: `cargo test --all-targets --locked` → 135/135 pass (unit 44 + layer1 32 + layer2 18 + layer3 9 + layer4 25 + layer5 7); `cargo clippy --all-targets --locked -- -D warnings` clean; `cargo fmt --check` clean.
+
+**Assumption surfacing (G-20):** `Option::is_none_or` was stabilized in Rust 1.82.0; `rust-toolchain.toml` pins 1.94.1, so usage is well within MSRV. `is_none_or(f)` desugars to `match self { None => true, Some(x) => f(x) }` — the "absent → wildcard" semantic the predicate relies on is the documented contract, not assumed. Rust's `&&` is short-circuit: the priority closure is only invoked when `issue.status == status` holds, and the label closure only when both prior conjuncts hold; a hand-edited `tracker.json` with a status that never matches will not invoke `label_matches`, but `load_issues` already validated status membership in `VALID_STATUSES` so this is academic. `Vec::retain` evaluates the predicate exactly once per element in iteration order; no repeated calls, no reordering. No assumed-but-nonexistent APIs.
+
+---
+
+### Resolved
+
+*(none — this round applied no impl fixes. Two findings raised; one Open and one Dismissed-with-rationale. The Open finding is a doc-comment precision issue, not an implementation bug, and can be fixed inline if SO sanctions; left Open for orchestrator routing alongside the Layer 5 batch outcome.)*
+
+---
+
+### Open
+
+**Finding 1 — `issue_matches_filters` rustdoc claims label is normalized lowercase by the caller; in fact label is case-preserved by spec and trim-only by `parse_label` (Dim 9 — Comments and self-documentation / Dim 1 — Doc-vs-impl correctness, narrow)**
+
+`src/lib.rs:416-424`:
+```rust
+/// Returns `true` iff `issue` matches every supplied filter.
+///
+/// The `status` filter is required (the default-open view passes `"open"`); the
+/// `priority` and `label` filters are optional (an absent filter is a wildcard).
+/// Filters AND-combine: a filter that mismatches makes the whole predicate false.
+/// Per DESIGN.md Feature 2 / Edge Cases / Labels, label comparison is
+/// case-sensitive and exact-match; priority and status comparisons assume the
+/// caller has already normalized the filter values (lowercase) and that stored
+/// values are normalized at write/load time.
+```
+
+The qualification "priority and status comparisons assume the caller has already normalized the filter values (lowercase)" is a *correct* scoping for those two fields — it does not include label. So this is not a contract bug. But the immediately preceding sentence — "label comparison is case-sensitive and exact-match" — leaves the reader to infer that `label` therefore needs *no* caller-side normalization. That inference is wrong: `cmd_list` does in fact normalize the label filter before calling the predicate — it runs `parse_label` to apply the **trim-on-store / trim-on-filter symmetry** the spec mandates (DESIGN.md line 312 / Edge Cases / Labels). A future maintainer reading the doc could reasonably conclude "label needs no preprocessing because it's exact-match" and skip the `parse_label` call when adding a new caller — which would silently break the trim-symmetry contract surfaced as UX R6 F1 / DE R7 F2 / SO R16 F2 / SE R12 F4.
+
+The doc gap is narrow but not hallucinated: it is exactly the class of comment that future-self maintainability (Dim 11) cares about, given that the *reason* for trimming the label filter is documented in `cmd_list` (line 479-484) but not in the predicate's contract block. The predicate body itself does not trim — and shouldn't — but the contract the predicate relies on the caller to satisfy includes "label is trim-normalized by the caller."
+
+**Evidence the trim-symmetry is a real and load-bearing contract:** `cmd_list` `src/lib.rs:485-488` invokes `parse_label(l)?` on the filter value, with the explicit comment naming "the round-trip asymmetry UX Review 6 / SO Review 16 surfaced." A predicate caller that bypassed `parse_label` (e.g., a Layer 6 `tracker show --label-eq <l>` flag that reused the predicate) would miss the trim normalization. The unit tests in `mod tests` all pass already-trimmed string literals (`"bug"`, `"Bug"`, `"feature"`), so they would not catch a caller that forgot to trim.
+
+**Proposed action:** Two-line tightening of the doc block to explicitly state the label-side caller obligation:
+
+```rust
+/// ... case-sensitive and exact-match (the caller is responsible for trim
+/// normalization — see `cmd_list`'s `parse_label` invocation; the spec's
+/// trim-on-store / trim-on-filter symmetry requires this); priority and
+/// status comparisons assume ...
+```
+
+Alternative, lighter touch: a single sentence appended after the existing doc block reading "Label values are compared verbatim: the caller must apply any trim or other normalization the spec requires (see `parse_label` and DESIGN.md Edge Cases / Labels)." Either works. Not applied inline this session because it crosses the SE/TW boundary at the margin (rustdoc clarification) and because the right wording is a stylistic call best made together with the orchestrator's batch outcome. SO/TW have no objection signal in advance — the change is informational, not contractual.
+
+**Classification:** Open — rustdoc-only fix, low risk, low value-but-real (Dim 9 / Dim 11). Recommended bundling with any other doc-tightening pass before Layer 6 lands a second predicate caller.
+
+---
+
+### Dismissed
+
+**Finding 2 — `issue_matches_filters` is module-private with no compile-time enforcement that callers normalize their inputs; the contract is documentation-only (Dim 3 — Type safety / Dim 8 — Defensive coding, design tradeoff)**
+
+The predicate signature is `fn issue_matches_filters(issue: &Issue, status: &str, priority: Option<&str>, label: Option<&str>) -> bool`. The status / priority / label parameters are bare `&str` / `Option<&str>` — no newtype, no enum. The contract "caller normalizes" is enforced only by code review and rustdoc, not by the type system. A newtype-wrapper approach (`struct NormalizedStatus<'a>(&'a str)`, `struct NormalizedPriority<'a>(&'a str)`, `struct NormalizedLabel<'a>(&'a str)` produced only by `parse_status` / `parse_priority` / `parse_label`) would make a non-normalized call a compile error.
+
+**Classification:** Dismissed. The same `&str` shape is used uniformly across `parse_status`, `parse_priority`, `parse_label`, `label_matches`, `priority_rank`, and the field types on `Issue` itself (`String`). Introducing newtypes only at the predicate boundary would create a one-off type system island that future maintainers would have to translate at every other boundary — net complexity adds, not subtracts. The project's existing pattern is "stringly-typed at boundaries, normalized at parse time, validated at load time" — and that pattern has been ratified across all prior SE rounds (SE Review 11 explicitly notes "stringly-typed status / priority is the project's chosen pattern"). The function is module-private (`fn`, not `pub`) and has exactly one caller (`cmd_list`); the caller's normalization is verifiable at a glance. If a Layer-6+ refactor introduces a second caller (e.g., a `cmd_show` that filters by ID + label, or a future `cmd_delete --by-label` operation), revisit. Logged for future-self.
+
+---
+
+**Finding 3 — Branch coverage gap in `issue_matches_filters` unit tests: no test for `priority=Some, label=None` or `priority=None, label=Some` matching cases (Dim 7 — Type-safety / coverage, QE-territory)**
+
+The Layer 5 unit tests cover:
+- All three filters present, all matching (`filter_and_logic_all_present_returns_true`)
+- All three filters present, each one of three single-mismatch cases (`filter_and_logic_all_must_match`)
+- All optionals absent, status matching (`filter_status_only_matches_any_priority_and_labels`)
+- All optionals absent, status mismatching (`filter_status_mismatch_rejects_regardless_of_optional_filters`)
+- All three present, label case-sensitivity (`filter_label_match_is_case_sensitive`)
+
+There is no unit test where exactly one optional is `Some` and one is `None`. The integration tests in `tests/layer5.rs` (`list_status_and_priority_filter_and_combination`, `list_status_and_label_filter_and_combination`, `list_priority_and_label_filter_and_combination`) cover these CLI-level cases, but at the unit level the predicate's "two-of-three present" matrix is not directly exercised.
+
+**Classification:** Dismissed for the SE lens. The truth-table walk shows the predicate is structurally symmetric across the two optional conjuncts: `priority.is_none_or(...)` and `label.is_none_or(...)` have identical shape, share the same short-circuit semantics, and the integration tests cover the cross-product. A unit test for the missing matrix cells would be defensive duplication of the integration coverage. Cross-reference QE Review 13 for whether to add the unit cases as belt-and-suspenders coverage; the SE-domain verdict is that the existing test set adequately pins the predicate's behavior. No action.
+
+---
+
+**Finding 4 — `cmd_list`'s 80-line responsibility mix (filter, empty-state, header, rows) persists through Layer 5; the predicate extraction is a partial improvement, not a closure (Dim 4 — Function design / Dim 5 — Duplication / Dim 6 — Complexity)**
+
+This is the SA R9 F1 / SE R11 F2 carry-forward. Layer 5 collapses three retain calls into one retain over `issue_matches_filters`, which is genuine progress on the *filter* axis: the AND-logic is now testable in isolation as a pure predicate, and the next filter dimension (Layer 6's possible `--description-contains` per `cmd_list`'s comment at line 489-495) extends a single named site rather than appending another retain. But the function still mixes:
+
+- Filter-value parsing (`parse_status`, `parse_priority`, `parse_label`)
+- Empty-state predicate computation (`extra_filter_active`, `is_default_open_view`)
+- Filter application (the new single retain)
+- Empty-state messaging (the two `eprintln!` branches)
+- Header row formatting (inline format string with literal column names + widths)
+- Per-row formatting (inline format string + inline truncation calls + inline `(none)` literal)
+
+Six responsibilities, ~80 lines. Column-width literals are still duplicated at four sites (`{:<4}  {:<11}  {:<8}  {:<20}` in header line 525, same in row line 538, `truncate_with_ellipsis(_, 20)` line 535, `truncate_with_ellipsis(_, 50)` line 536). SE R11 F2 / SA R9 F1's recommended `filter_issues` / `format_header_row` / `format_issue_row` extraction with module-level constants is **not closed by Layer 5** — it is partially advanced in that the *filter* helper is now extracted, but the formatting helpers and constants are unchanged.
+
+**Classification:** Dismissed for *Layer 5 itself* — Layer 5's scope per TODO.md:239-275 is the AND-combination predicate, not a `cmd_list` rendering refactor. Layer 5 made the predicate side cleaner without making the rendering side worse. **The carry-over remains Open** under SE R11 F2 / SA R9 F1; SO R17 explicitly deferred the broader `cmd_list` extraction to the focused PR before Layer 7. Closing-status update for the carry-forward record: **partially advanced (predicate extracted), broader refactor still deferred to pre-Layer-7 focused PR per SO R17.**
+
+---
+
+### Hallucinated
+
+*(none. Finding 1 is a real doc-precision concern verified against the predicate's actual caller (`cmd_list`'s `parse_label` invocation) and against the spec's trim-symmetry mandate (DESIGN.md line 312). Findings 2–4 are real defensive/structural observations that have been deliberately scoped out with rationale, not invented concerns. Per the primer's MVR criterion — "running out of real complaints is reached only when every remaining finding has been demonstrated to be hallucinated, not merely declared so" — this round is dismissed-with-rationale only, which is one half-step short of the formal MVR endpoint. The single Open finding (doc precision on the predicate's caller-normalization contract) is genuinely a real-but-narrow concern.)*
+
+---
+
+### Carry-over check (prior-finding closure status)
+
+- **SA R9 F1 / SE R11 F2 (cmd_list extraction with column-width constants):** **Partially advanced, still Open.** Layer 5 extracted the filter predicate; the rendering / formatting helpers (`format_header_row`, `format_issue_row`) and module-level column-width constants are unchanged. Continues to be deferred to the focused pre-Layer-7 PR per SO R17. Filing this round's evidence under the same Open record (Finding 4 above).
+- **SE R11 F3 (label control-character defense):** **Closed in SE R12 (commit `67ef920`)**, verified again this round at `src/lib.rs:379-391` (`parse_label` rejects control chars and comma) and `src/lib.rs:145-147` (`label_is_valid` enforces same rules at load). No regression at Layer 5.
+- **SE R10 F1 (duplicate-ID validation gap):** Closed in Layer 3 follow-up. Verified unchanged at `src/lib.rs:173-176` (`issues_collection_invariants_hold`) and called from `load_issues` at line 197-201. No regression at Layer 5.
+- **SE R10 F2 (empty/whitespace label storage validation):** Closed; `issue_fields_are_valid` calls `label_is_valid` per `src/lib.rs:131`. No regression.
+- **SE R10 F3 (`updated_at >= created_at` invariant):** Closed; enforced at `src/lib.rs:138`. No regression.
+- **SO R11 regression hazard (positive-enumeration empty-state predicate):** Closed in SE R11 F1 via the `extra_filter_active` disjunction at `src/lib.rs:496-497`. Layer 5's `is_none_or` predicate body is structurally a different (and more localized) form of the same fix; if a Layer 6 filter is added, both `extra_filter_active` (for the empty-state branch) and `issue_matches_filters` (for the match branch) need the new conjunct added — two places, but each is named and narrow. No regression.
+
+---
+
+### Summary
+
+Cold-session SE Review 13 outcome on Layer 5 (Compound Filtering): **0 resolved, 1 Open (doc precision), 3 Dismissed-with-rationale, 0 Hallucinated.**
+
+**Top SE concern:** Finding 1 — `issue_matches_filters` rustdoc declares "label comparison is case-sensitive and exact-match" without disclosing that the *trim* normalization is the caller's obligation. The predicate body does not trim; `cmd_list` does, via `parse_label`; a future second caller could miss the obligation. Narrow-but-real Dim 9 / Dim 11 concern. Doc-only fix recommended, two lines, low risk, no impl change.
+
+**Predicate correctness verdict:** The truth-table walk holds — `issue.status == status && priority.is_none_or(|p| issue.priority == p) && label.is_none_or(|l| label_matches(&issue.labels, l))` correctly implements the AND-combination across all 8 cells of the (priority∈{None,Some-match,Some-mismatch}) × (label∈{None,Some-match,Some-mismatch}) × (status∈{match,mismatch}) cube. Short-circuit on `&&` guarantees the priority and label closures are not evaluated when status mismatches; the closures themselves use `is_none_or` (Rust 1.82+, well within the 1.94.1 toolchain pin). The extracted predicate is testable in isolation, and the 5 Red Gate unit tests cover the highest-value cells. Behavior is identical to the prior chained-retain form (the commit message states this and the integration tests verify it: 7 Cat-B Red Gate tests in `tests/layer5.rs` pass without modification). The refactor is net **−5 lines** in `src/lib.rs` (per the `bd15a9d` diff stat: +11 −16) and removes the multi-pass retain in favor of a single-pass walk.
+
+**Carry-over closure status:**
+- **SA R9 F1 / SE R11 F2 (cmd_list extraction):** Partially advanced (filter predicate extracted), broader rendering refactor still Open per SO R17 deferral.
+- **SE R11 F3 (label control-char defense):** Already closed in SE R12; verified no regression at Layer 5.
+- **SE R10 F1/F2/F3 (validator gaps):** Already closed in Layer 3 follow-up; verified no regression.
+
+**Layer 5 SE verdict:** Implementation is sound on every spec-internal correctness path — AND-combination across two filters, three filters, all single-mismatch rejections, default view non-empty, default view empty-state messaging, filter view empty-state messaging. All 8 acceptance criteria from TODO.md:243-251 are met by the test suite (7 integration tests in `tests/layer5.rs` plus 5 unit tests in `src/lib.rs#tests`). MSRV is satisfied. Clippy + fmt clean. Refactor reduces line count and improves testability without behavior change. The only SE-domain concern is the rustdoc precision issue (Finding 1) — a real-but-narrow gap that is doc-only and risk-free to fix.
+
+**Sycophancy check:** Three potential softenings considered and pushed back on:
+1. *Was the predicate-extraction-is-clean conclusion reached because no counterexample came to mind, or because the truth table was actually walked?* — The 8-cell truth table was walked explicitly above, with the `is_none_or` semantic checked against rustdoc, before reading the existing tests. Conclusion holds.
+2. *Was Finding 1 dismissed as "merely a doc nit" too easily?* — Pushed back by tracing the historical context: the trim-symmetry contract was a Round-2 closure for UX R6 F1 / DE R7 F2 / SO R16 F2 — a contract that *did* break in production-ish testing on the prior layer and required spec amendment to fix. A doc gap that could lure a future caller back into the same trap is non-trivial. Logged as Open.
+3. *Was Finding 4 (cmd_list extraction) suppressed because SA owns it?* — No: the SE-lens framing is logged in Finding 4 with the partially-advanced status update for the carry-forward record. The classification is Dismissed for *this* round's scope only; the SE R11 F2 Open record continues unchanged.
+
+The dismissal-test was applied to Findings 2 and 3 specifically: for Finding 2 (no compile-time enforcement of caller normalization), the dismissal holds because the project-wide pattern is `&str`-at-boundaries, ratified in prior rounds, and a one-off newtype island would add net complexity. For Finding 3 (branch coverage gap on two-optional cases), the dismissal holds because the predicate is structurally symmetric across the two optionals and integration tests cover the matrix; a unit-test addition would be belt-and-suspenders rather than load-bearing. Neither dismissal is "passes because no counterexample" — both are explicit cost/benefit calls.
+
+**Coordination:**
+- **SO Review 18:** No spec change requested from the SE lens. The doc-precision fix in Finding 1 is contained to rustdoc and does not require a DESIGN.md amendment. SO's Layer 5 spec-compliance review is independent.
+- **SA Review 11:** SA's `cmd_list` extraction record (SA R9 F1) is now in "partially advanced" status for the cross-domain ledger; the predicate side is extracted, the rendering side is unchanged. SA may wish to note in its own review that Layer 5 reduces the pressure on the `filter_issues` extraction (the filter logic now has named, testable form) without reducing the pressure on `format_header_row` / `format_issue_row` / column-width constants.
+- **QE Review 13:** Cross-reference Finding 3 — branch-coverage gap on `priority=Some,label=None` / `priority=None,label=Some` matching cases. SE-domain verdict is that integration tests cover the matrix; QE may decide whether to add the missing unit cells as defense-in-depth (low cost, ~6 lines).
+- **VDD-IAR Review 13:** Layer 5 is a clean Phase-2-Red-Gate-then-impl two-step (`7d1ca57` → `bd15a9d`), with the Red Gate genuinely failing (5 unit tests panicked under `todo!()`) and Phase 2b genuinely passing them. The Cat B integration tests are correctly disclosed as deviations in `tests/layer5.rs:14-24`. No process concern from the SE lens.
+- **Red Team:** No new Red-Team-relevant integrity concerns at Layer 5. The predicate is a pure function; no new I/O or state surface.
+- **Security:** No new Security findings. The `display_safe` formatter sanitization (added in SE R12) covers the parse-error paths; the predicate itself does not interpolate user input into stderr.
+
+**Files modified this session:** `iterative-adversarial-refinement/SOFTWARE-ENGINEER-REVIEW.md` only (this entry). No `src/**/*.rs` changes.
+
+---
+
+## Review 14 — 2026-05-07 00:42Z
+
+**Round:** SE Review 14 (Round-2 closure for Layer 5)
+**Scope:** Verify SE R13 F1 (rustdoc on `issue_matches_filters` does not disclose label-trim caller obligation) is resolved by commit `7f9bae4`. Warm closure-verification.
+
+### Round-1 finding closure
+
+- **F1 (rustdoc precision on label trim normalization):** **Resolved.** `src/lib.rs:416-428` rustdoc gains a sentence: "The caller is also responsible for applying any other normalization the spec requires before calling — notably trimming the label filter (DESIGN.md Edge Cases / Labels mandates trim-on-store / trim-on-filter symmetry; `cmd_list` runs `parse_label` on the filter value to satisfy this)." This explicitly documents the label-side caller obligation, with cross-references to the spec contract (DESIGN.md Edge Cases / Labels) and the canonical caller (`cmd_list` + `parse_label`). A future second predicate caller (e.g., a hypothetical Layer 6 `cmd_show` filter overload) will see the obligation in the contract block, defending against the trim-symmetry regression lineage (UX R6 F1 / DE R7 F2 / SO R16 F2 / SE R12 F4).
+
+### New findings
+
+*(none this round.)*
+
+### Carry-forward verification
+
+- **SA R9 F1 / SE R11 F2 (full `cmd_list` extraction):** Partially advanced at Layer 5 (filter predicate extracted), still Open for the rendering half. Disposition unchanged: deferred to focused pre-Layer-7 PR per SA R10 / SA R11 / SO R17.
+- **SE R11 F3 (label control-char defense):** Already closed in SE R12 (commit `67ef920`); no regression at Layer 5.
+- **SE R10 F1/F2/F3 (validator gaps):** Already closed in Layer 3 follow-up; no regression.
+
+### Summary
+
+1/1 Round-1 SE finding Resolved. 0 new findings this round. Layer 5 SE-domain is closed at MVR.
+
+**Coordination:** *(none — closure pass)*
+
+---

--- a/issue-tracker-cli/iterative-adversarial-refinement/SOLUTION-ARCHITECT-REVIEW.md
+++ b/issue-tracker-cli/iterative-adversarial-refinement/SOLUTION-ARCHITECT-REVIEW.md
@@ -804,3 +804,159 @@ Round-1 F2 verified Resolved (and the resolution survived contact with new filte
 
 ---
 
+---
+
+## Review 11 — 2026-05-07 00:23Z
+
+**Round:** SA Review 11 (Layer 5 — Compound Filtering).
+**Scope:** Cold-session adversarial SA review of the Layer 5 implementation (commits `7d1ca57` Phase 2a Red Gate, `bd15a9d` Phase 2b implementation, `da0fd8d` manual-testing checklist closure). Code under review: `src/lib.rs` (948 lines incl. tests), `src/main.rs`, `tests/layer5.rs`. Primary lens: dim 1 (separation of concerns), dim 2 (cohesion), dim 3 (coupling), dim 4 (interface contracts), dim 5 (complexity budget), dim 6 (decision documentation), and the SA Review 9 carry-forward findings (F1 cmd_list extraction, F2 extra_filter_active disjunction).
+**Session note:** Cold session per the IAR primer. Adversarial framing intact. Parallel batch with SO 18 / QE 13 / SE 13 / VDD-IAR 13. Sycophancy guard: every prior Open / Resolved finding from SA 8/9/10 was specifically re-validated against the Layer 5 source — particularly the SA R10 "Resolved" verdict on F2 (extra_filter_active disjunction).
+
+---
+
+### Open
+
+**Finding 1 — Layer 5's predicate extraction closed the *filter* half of SA Review 9 Finding 1; the *rendering* half (column-width constants + `format_header_row` / `format_issue_row` extraction) remains untouched. The Layer 7 collision argument is unchanged (Dim 1 — Separation of concerns / Dim 12 — Purity boundary / Carry-forward of SA R8 F1 → SA R9 F1)**
+
+`src/lib.rs:425-434` — `issue_matches_filters` is now a named pure predicate with five unit tests (`filter_and_logic_all_present_returns_true`, `filter_and_logic_all_must_match`, `filter_status_only_matches_any_priority_and_labels`, `filter_status_mismatch_rejects_regardless_of_optional_filters`, `filter_label_match_is_case_sensitive`). `cmd_list:500-507` collapses three chained `retain` calls into a single `retain` over the predicate. This is a real architectural improvement and partially discharges SA R9 F1: the filter logic is now testable in isolation, and any future filter (e.g. a hypothetical Layer 8 `--created-since`) extends the predicate at one site rather than appending another `retain` to `cmd_list`.
+
+The *rendering* half of SA R9 F1 is unchanged. The four scattered column-width literals are still scattered:
+
+- `src/lib.rs:525` — header format string `"{:<4}  {:<11}  {:<8}  {:<20}  Title"`
+- `src/lib.rs:535` — `truncate_with_ellipsis(&labels_raw, 20)`
+- `src/lib.rs:536` — `truncate_with_ellipsis(&issue.title, 50)`
+- `src/lib.rs:538` — row format string `"{:<4}  {:<11}  {:<8}  {:<20}  {}"`
+
+No module-level `ID_WIDTH` / `STATUS_WIDTH` / `PRIORITY_WIDTH` / `LABELS_WIDTH` / `TITLE_WIDTH` constants exist. No `format_header_row()` / `format_issue_row(&Issue)` helpers exist. `cmd_list` still mixes load (effect) → filter (now pure via predicate) → empty-state branch (effect, two messages) → sort (pure) → header `println!` (effect) → row `println!` loop (effect) in a single function body of ~80 lines. The Layer 7 collision argument from SA Review 8 stands unchanged: ANSI escape bytes injected into priority/status values before they reach `{:<11}` / `{:<8}` will break column padding because Rust's `{:<width}` counts escape bytes as visible chars, and the rewrite Layer 7 will need to do still spans four width-literal occurrences plus two scattered format strings.
+
+**Self-test (sycophancy guard):** could this be dismissed as "rendering extraction is genuinely a Layer 7 concern"? No — the original SA R8 F1 finding was specific that doing the extraction in Layer 7 *alongside* `IsTerminal` plumbing and color injection conflates two unrelated changes; doing it before Layer 7 is the architecturally cheaper path. Layer 5 touched `cmd_list` (the predicate refactor, the chained-retain collapse) and was the third natural opportunity to address the rendering half. The work was scoped to predicate extraction only. The Layer 7 prep is still in front of the project.
+
+**Severity:** Low-to-medium. Half of SA R9 F1 is now genuinely closed; the architectural improvement is real (filter logic is unit-testable, predicate is the future-extension site). The remaining half is the same shape it has been since SA R8 — a known, tracked, deferred refactor.
+
+**Classification: Open (Deferred to a focused PR before Layer 7).** Same disposition as SA R10's verdict on the original F1: deferred to a focused PR with its own test scaffolding, not bundled with another layer's behavioral work. SO Review 17 already records this deferral with the named target. This finding is the narrowed re-raise: the predicate extraction *did* close half the original concern, and that progress should be acknowledged.
+
+**Proposed action:** Track as a pre-Layer-7 PR (existing deferral). Recommended scope at that time: introduce `ID_WIDTH`/`STATUS_WIDTH`/`PRIORITY_WIDTH`/`LABELS_WIDTH`/`TITLE_WIDTH` module-level `const` items; extract `format_header_row()` and `format_issue_row(&Issue)`; thread the format-width literals through `format!("{:<width$}", ..., width = STATUS_WIDTH)` so the `:<11}` / `:<20}` widths and the `truncate_with_ellipsis(_, 20)` / `truncate_with_ellipsis(_, 50)` caps share a single source of truth.
+
+**Coordination:** Cross-reference with [SOFTWARE-ENGINEER-REVIEW.md](SOFTWARE-ENGINEER-REVIEW.md) (CLI supplement § Software Engineering — output formatting separation, structured result types before formatting). No new SE referral; the existing pre-Layer-7 deferral covers it.
+
+---
+
+### Resolved
+
+**Finding 2 — Predicate-extraction half of SA Review 9 Finding 1 (Carry-forward / Dim 1)**
+
+The predicate-extraction half of SA R9 F1 is now closed by Layer 5: `issue_matches_filters` is a named pure function (`src/lib.rs:425-434`) with five focused unit tests. `cmd_list` no longer carries inline filter closures; the AND-combination is testable at the unit level and visible at one site. Future filter additions extend the predicate's body or signature, not the call site.
+
+**Classification: Resolved (predicate-extraction half).** Re-validated against the Layer 5 source. The remaining rendering-extraction half is tracked as Finding 1 above.
+
+---
+
+**Finding 3 — `extra_filter_active` disjunction property survives Layer 5 (Carry-forward / Dim 7 — Extensibility / SA R8 F2 → SA R9 F2 → SA R10)**
+
+SA Review 10 verified F2 Resolved: `cmd_list` uses a named `extra_filter_active = effective_priority.is_some() || effective_label.is_some()` disjunction (`src/lib.rs:496`), and the empty-state predicate consumes it as `effective_status == "open" && !extra_filter_active` (`src/lib.rs:497`). Layer 5 did not add a new filter dimension (compound filtering is the AND of existing dimensions), so the disjunction was not re-tested by source change.
+
+The Layer 6 risk to this property is bounded: per DESIGN.md (line 207-208), `--description` is on `tracker create` only, not `tracker list`. Layer 6 will not extend the `cmd_list` filter set. The property holds for the spec as written. If a future hypothetical filter (a `--description-contains` polish, etc.) is added to `list`, it will need to extend the disjunction at one site — which is exactly the property the original finding was designed to ensure.
+
+`tests/layer5.rs::list_compound_three_filter_no_match_shows_filter_message` is a regression check on this property: the label filter alone is the odd-one-out, so a regression that dropped `--label` from `extra_filter_active` would route to "No open issues. Nice work!" instead of "No issues match the given filters." and the test would fail.
+
+**Classification: Resolved (re-verified for Layer 5).** Property holds; regression check exists; spec-as-written has no Layer 6 filter additions to threaten it.
+
+---
+
+### Dismissed
+
+**Finding 4 — Predicate signature asymmetry (`status: &str` required, `priority`/`label: Option<&str>` optional) is undocumented at the contract level beyond the doc comment; risk of misuse if a caller passes a non-normalized status (Dim 4 — Interface contracts)**
+
+`src/lib.rs:425-434`. The predicate signature is asymmetric: `status` is required, `priority` and `label` are optional. The function uses `==` for status equality (`issue.status == status`) — case-sensitive byte comparison. A caller that passed `"OPEN"` rather than `"open"` would silently no-match every issue. The doc comment (`src/lib.rs:421-424`) explicitly notes "priority and status comparisons assume the caller has already normalized the filter values (lowercase) and that stored values are normalized at write/load time," which addresses the contract but does not enforce it.
+
+**Classification: Dismissed.** Demonstration that the control holds:
+
+1. **The function is private** (`fn`, not `pub fn`), so external misuse is impossible. The only call site is `cmd_list` (`src/lib.rs:500-507`).
+2. **The single call site normalizes inputs**: `effective_status` is the result of `parse_status(s)?` (`src/lib.rs:471-474`) which lowercases unconditionally; `effective_priority` is the result of `parse_priority(p)?` (`src/lib.rs:475-478`) which also lowercases. `effective_label` flows through `parse_label` (`src/lib.rs:485-488`) which trims but does not case-normalize — but label comparison is *spec-required* to be case-sensitive (DESIGN.md "Labels filter matches case-sensitively"), so passing the raw trimmed value is correct.
+3. **Stored values are normalized at write/load time**: `parse_status` lowercases on input to `cmd_status` and `cmd_create`; `parse_priority` lowercases on input to `cmd_create`; `issue_fields_are_valid` rejects non-canonical stored values at load (`src/lib.rs:129-130`).
+4. **The doc comment is the contract for an internal helper.** Promoting the contract from doc-comment-on-private-fn to a type-level invariant (e.g., an enum-typed `Status` parameter) was already evaluated and Dismissed in SA R8 F4 / SA R6 F1 / SA R7 F1 with re-raise condition "if a defect is found that an enum would have caught at compile time." No such defect has surfaced.
+
+The control holds: no realistic path exists for a misuse to land. Marking this finding Dismissed requires demonstrating the control specifically; the demonstration is above.
+
+**Re-raise condition:** if `issue_matches_filters` is ever made `pub` (exported from the library), or if a future Layer's `cmd_*` handler grows a second call site that does not flow through `parse_status` / `parse_priority`, revisit immediately — the doc-comment contract is too weak for an exported API or a multi-call-site predicate.
+
+---
+
+**Finding 5 — DECISIONS.md has no Layer 5 entry; the predicate-extraction architectural choice is captured only in the commit messages of `7d1ca57` and `bd15a9d` (Dim 6 — Decision documentation)**
+
+DECISIONS.md (107 lines, last updated for Layer 3 SO Review 13 spec amendments) has entries for atomic-write deferral, line-ending non-normalization, control-character-rejection-in-titles, empty-state-stderr-routing, and SE Review 9 ratification — but no Layer 4 or Layer 5 entries. The Layer 5 architectural decision (extract `issue_matches_filters` as a private predicate rather than a `filter_issues(...) -> Vec<Issue>` form, collapse three retains into one, defer the rendering split per SA R10) is documented in the commit messages of `7d1ca57` Phase 2a Red Gate and `bd15a9d` Phase 2b implementation. A future reviewer reading DECISIONS.md cold will not see why the predicate is private, why `is_none_or` was chosen over a match, or why the rendering split was deferred.
+
+**Classification: Dismissed.** DECISIONS.md is a record of *durable* architectural choices and *spec amendments* — atomic-write deferrals, control-character rejection, stream-routing changes. The predicate extraction is an internal refactor of a private function with no spec-visible behavior change ("Behavior is unchanged from the prior chained-retain form" per the `bd15a9d` commit message). The commit-message rationale is the appropriate documentation venue for this class of change. DECISIONS.md should not become a refactor log; it would dilute the durable-decision signal.
+
+**Re-raise condition:** if Layer 5 had introduced a *spec-visible* architectural choice (a new public API, a behavior change, a stream-routing change, etc.), DECISIONS.md would be the right venue. None did. If a future layer's refactor introduces a spec-visible architectural decision, DECISIONS.md is the right venue at that point.
+
+---
+
+### Hallucinated
+
+**Finding 6 — `issue_matches_filters` couples to `Issue` struct shape (`issue.status`, `issue.priority`, `issue.labels` field reads); a future change to `Issue` would propagate to the predicate (Dim 3 — Coupling)**
+
+Initial concern: the predicate reads three `Issue` fields directly. If `Issue.status` ever became `Issue.state`, the predicate would need updating. Decoupling via accessor methods (`issue.status()`, `issue.priority()`, `issue.labels()`) would isolate the predicate from struct-shape change.
+
+**Classification: Hallucinated.** Demonstration that the control holds:
+
+1. **`Issue` is the data model, not a service abstraction.** Coupling a filter predicate to the data model it filters is *the correct* coupling shape. Decoupling via accessors would add ceremony for no benefit — accessor methods that just return `&self.field` are noise that obscure the intent.
+2. **The `Issue` struct shape is fixed by DESIGN.md.** DESIGN.md (lines 162-171) specifies the field names and types as part of the storage contract. A field rename would require both a DESIGN.md spec amendment AND a migration story for existing `tracker.json` files. The "what if a field gets renamed" hypothetical does not have a realistic path.
+3. **Direct field reads are the Rust-idiomatic pattern for internal predicates.** A `pub fn matches(&self, ...)` on `Issue` would be the alternative, but moving the predicate to an `impl` block on `Issue` would couple `Issue` (the data model) to filter semantics (a `cmd_list` concern), which is a worse architectural shape than the current arrangement.
+
+The control holds: the coupling is the correct coupling for an internal-predicate-over-data-model pattern. Marking this finding Hallucinated requires demonstrating the alternative would be worse, and the demonstration is above.
+
+---
+
+### Summary
+
+One real finding — a narrowed carry-forward of SA R9 F1: the predicate-extraction half is now closed (filter logic is unit-testable; AND-combination is one named function), but the rendering-extraction half (column-width constants + header/row formatters) is unchanged. Layer 5 was the third natural opportunity to do that work; it remained scoped out. The Layer 7 collision argument is unchanged. Disposition: Open — Deferred to a focused PR before Layer 7 (same disposition as SA R10's verdict on the original F1).
+
+Two findings Resolved (re-verified for Layer 5): predicate-extraction half of SA R9 F1, and the `extra_filter_active` disjunction property from SA R8/R9/R10 F2. The disjunction property was not re-tested by source change in Layer 5 (no new filter dimension was added), and the Layer 6 risk is bounded by the spec (`--description` is on `create` only, not `list`).
+
+Two findings Dismissed (predicate signature asymmetry — function is private, single normalized call site, doc comment is the contract; DECISIONS.md absent Layer 5 entry — internal refactor with no spec-visible behavior change is the wrong venue for DECISIONS.md). One finding Hallucinated (predicate coupling to `Issue` struct shape — direct field coupling is the correct pattern for an internal predicate over a data model).
+
+**Complexity budget (Dim 5):** `git show bd15a9d --stat` shows `+19/-24` for `src/lib.rs` — net **−5 lines** in the implementation commit. Phase 2a Red Gate added `+107` (predicate stub + 5 unit tests + helper); Phase 2b reduced `cmd_list` body. Net Layer 5 source change is +102 lines, dominated by tests and doc comments. The refactor genuinely shrunk the function body while adding testability — the right direction. `lib.rs` is now 948 lines total, with ~485 non-test lines (estimate: tests-and-helpers section starts at line 546). Approaching the 500-non-test-lines re-raise threshold (SA R9 Finding 3 revised condition), but not over it. Tracking note for SE Layer 6 scoping unchanged.
+
+**Layer boundary (Dim 1):** Respected. No Layer 6 / show / delete / description bleed into Layer 5 source. The predicate has no description filter even though `Issue.description` exists; clean.
+
+**Sycophancy check:** Two findings I tried to dismiss but could not:
+- Finding 1 (rendering-extraction half remains): I tried to dismiss as "Layer 7 concern" — but SA R8 F1 explicitly argued doing it in Layer 7 conflates two changes, and Layer 5 was the third natural touch-point. Dismissal unconvincing → finding stands as Open (narrowed).
+- The original F2 (extra_filter_active) — I tried to find a way it had regressed in Layer 5. It hasn't. Layer 5 didn't touch the disjunction at all because it didn't add a filter dimension. The "Resolved (re-verified)" verdict survives the dismissal attempt → confirmed Resolved.
+
+Two findings I tried to elevate but couldn't:
+- Predicate signature asymmetry (Finding 4) — I tried to argue the doc-comment contract is too weak. But the function is private and the single call site normalizes inputs. Elevation unconvincing → finding stands as Dismissed with explicit re-raise condition.
+- DECISIONS.md absent Layer 5 entry (Finding 5) — I tried to argue future reviewers will lack context. But DECISIONS.md is for spec amendments and durable choices; an internal refactor is not the right venue. Elevation unconvincing → finding stands as Dismissed.
+
+**Carry-forward status (explicit):**
+- **SA R9 F1 (cmd_list extraction):** Predicate-extraction half **closed by Layer 5**. Rendering-extraction half **still Open** (Deferred to pre-Layer-7 focused PR). Net progress.
+- **SA R9 F2 (extra_filter_active disjunction):** **Resolved**, re-verified for Layer 5. No new filter dimension added; property holds; regression check exists in `tests/layer5.rs:312-350`.
+- **SA R8 F3 (lib.rs decomposition past 500 non-test lines):** ~485 non-test lines now (estimate). Below threshold. Tracking note for Layer 6.
+- **SA R8 F4 (`cmd_create` parameter count):** still 4. Threshold at 5. Layer 6's `--description` reaches threshold. Tracking note unchanged.
+
+**Coordination:**
+- **No new SE referral.** Finding 1 (rendering-extraction half) is the existing pre-Layer-7 deferred PR, already tracked.
+- **For QE (informational):** the Layer 5 unit tests (`filter_and_logic_*`, `filter_status_*`, `filter_label_match_is_case_sensitive`) genuinely close the "filter logic is testable only via subprocess integration" gap from SA R8 F1. The integration tests in `tests/layer5.rs` are correctly disclosed as Cat B Red Gate deviations (the AND-combination was emergent from prior layers).
+- **For SO (informational):** no DESIGN.md changes proposed by SA. The compound-filter behavior is spec-faithful; the predicate-extraction is an internal refactor.
+- **For VDD-IAR (informational):** the Phase 2a/2b split (Red Gate first, predicate body second) was executed as documented; the Phase-2a-only `#[allow(dead_code)]` was correctly removed at Phase 2b. Process compliance is intact from SA's lens.
+
+---
+
+## Review 12 — 2026-05-07 00:40Z
+
+**Round:** SA Review 12 (Round-2 closure for Layer 5)
+**Scope:** Verify SA R11 disposition holds after Round-1 inline fixes commit `7f9bae4`. Warm closure-verification, not a new adversarial pass.
+
+### Round-1 finding status
+
+- **F1 (rendering half of `cmd_list` extraction — column-width literals × 4 sites, no `format_*_row` helpers):** **Open / Deferred unchanged.** The Round-1 inline fixes did not touch the rendering half of `cmd_list` (correctly — the SA R11 disposition is "deferred to focused pre-Layer-7 PR"). SA confirms this finding is *not* claimed Resolved by `7f9bae4` and remains the only suite-wide Layer 5 Open finding pending Layer 7 prep.
+
+### New findings
+
+*(none this round. The other Round-1 inline fixes — SO F1/F2/F3, QE F1, SE F1 — are doc-precision-class changes that don't intersect SA's separation-of-concerns / coupling lens.)*
+
+### Summary
+
+SA R11 F1 carry-forward unchanged: deferred. 0 new findings this round. From SA's lens, Layer 5 is merge-ready; the rendering-half deferral is bookkept for the focused PR before Layer 7.
+
+**Coordination:** *(none — closure pass)*

--- a/issue-tracker-cli/iterative-adversarial-refinement/SOLUTION-OWNER-REVIEW.md
+++ b/issue-tracker-cli/iterative-adversarial-refinement/SOLUTION-OWNER-REVIEW.md
@@ -1500,3 +1500,197 @@ No source files modified by this review (SE applies code per the spec amendments
 ### Summary
 
 7 Round-2 resolutions logged: SO R16 F1/F2/F3/F4 (3 directly resolved + F3 closed by manual-testing commit), Security R7 F1, RT R6 F1/F2/F3 (F1+F2 resolved; F3 Accepted Risk), DE R7 F1/F2, SE R11 F3, UX R6 F1/F4, TW R7 F2/F4/F7. 5 findings deferred with named target layers (SA R9 F1 / SE R11 F2 / UX R6 F2/F3 / TW R7 F6 → Layer 7). 1 finding remains Open requiring developer-only action (TW R7 F5).
+
+---
+
+## Review 18 — 2026-05-07 00:23Z
+
+**Round:** SO Review 18 (Layer 5 — Compound Filtering)
+**Scope:** Layer 5 (status × priority × label AND-combination + filter-empty-state messaging) primary. Three commits to evaluate: `7d1ca57` (Phase 2a Red Gate — `issue_matches_filters` `todo!()` stub + 5 unit tests + 7 integration tests), `bd15a9d` (Phase 2b — predicate body + `cmd_list` retain refactor), `da0fd8d` (manual testing checklist closure). Secondary: spot-check that no Layer 6/7 surface leaked in.
+**Reference:** `DESIGN.md` Feature 2 (lines 51-82, 316-322), `TODO.md` Layer 5 (lines 239-275), assignment brief Layer 5 ("Compound filter").
+**Session note:** Cold session, fresh subagent. Parallel-batch IAR run on branch `issue-tracker-cli-compound-filtering` with SA Review 11, QE Review 13, SE Review 13, VDD-IAR Review 13. SO did not participate in Layer 5 scoping or implementation.
+
+---
+
+### Compliance table — Layer 5 acceptance criteria
+
+| AC (TODO.md lines 244-251) | Status | Evidence |
+|---|---|---|
+| `--status open --priority high` shows only open AND high-priority | Met | `tests/layer5.rs:28-73` `list_status_and_priority_filter_and_combination`; predicate `src/lib.rs:425-434`. |
+| `--status open --label bug` shows only open with label `bug` | Met | `tests/layer5.rs:75-117` `list_status_and_label_filter_and_combination`. |
+| `--priority high --label bug` shows only high + bug | Met | `tests/layer5.rs:119-181` `list_priority_and_label_filter_and_combination`. |
+| `--status open --priority high --label bug` shows only triple-match | Met | `tests/layer5.rs:185-279` `list_three_filter_and_combination`. |
+| 2/3-match issue does NOT appear | Met | Same test — three negative assertions, one per single-filter mismatch. |
+| `--status done --priority low` no-match → `No issues match the given filters.` | Met | `tests/layer5.rs:283-310` `list_compound_two_filter_no_match_shows_filter_message`; asserts stdout empty + stderr message + absence of `Nice work!`. |
+| `--status open --priority high --label nonexistent` no-match → filter message | Met | `tests/layer5.rs:312-350` `list_compound_three_filter_no_match_shows_filter_message`. |
+| `tracker list` (default, opens exist) → no `No issues match` message | Met | `tests/layer5.rs:352-384` `list_default_view_with_open_issues_does_not_show_filter_message`; asserts `Nice work!` and `No issues match` both absent. |
+| Predicate `issue_matches_filters` AND-combines status/priority/label | Met | `src/lib.rs:431-433` — `issue.status == status && priority.is_none_or(|p| issue.priority == p) && label.is_none_or(|l| label_matches(...))`; 5 unit tests `src/lib.rs:867-930`. |
+| Manual testing checklist (TODO.md lines 255-261) | Verified | All six items flipped to `[x]` in commit `da0fd8d`; expected outputs match the implementation under spot-trace (see Finding 2). |
+| `Cargo.toml` unchanged (no new deps) | Met | `git diff 921525d..HEAD -- issue-tracker-cli/Cargo.toml issue-tracker-cli/Cargo.lock` returns empty. |
+| Test count regression check | Met | `cargo test --no-fail-fast --locked` → 32+18+9+25+7 integration + 44 unit = 135 passing, 0 failing. |
+| No Layer 6+ surface (no `show`, no `delete`, no `--description`) | Met | `src/main.rs:11-43` enum still `Create | List | Status`. |
+
+All eight Layer 5 ACs are Met. Manual checklist closed. No new dependencies. No Layer 6/7 leakage. Test count is 135/135.
+
+---
+
+### Findings
+
+#### Finding 1: `cmd_list` comment cites `--description-contains` as a future Layer 6 filter, contradicting DESIGN.md "Out of Scope" exclusion of text search
+
+- **Dimension:** Dim 1 (Spec coverage), Dim 2 (Scope creep — anticipatory), Dim 7 (Design fidelity)
+- **Severity:** Low
+- **Evidence:**
+  - `src/lib.rs:489-490`: "Disjunction over non-default filters: any future filter (e.g. Layer 6's `--description-contains`) must extend `extra_filter_active` here…"
+  - DESIGN.md "Out of Scope" line 397: "**Search by text** — no full-text search across titles or descriptions; filtering is by exact-match status, priority, and label only".
+  - DESIGN.md TODO.md Layer 6 (lines 279-345): no `--description-contains` flag is named in any AC; Layer 6 adds `tracker show`, `tracker delete`, and `--description` on `create` only — no description filter.
+  - The bd15a9d commit message reinforces the same aspirational direction: "future filters (Layer 6's optional --description-* flag and beyond) extend one place rather than appending another retain".
+  - The comment was added in an earlier layer (preexisting at the start of the Layer 5 diff), so this is not Layer 5's new creep — but Layer 5's commit message ratifies the same anticipated extension.
+- **Rationale:** A code comment that names a feature DESIGN.md excludes is anticipatory scope creep at the documentation level. Future-proofing for a feature the spec forbids ("filtering is by exact-match status, priority, and label only") signals to the next reader that the author considers the exclusion soft. This is the same defect class SO has caught before (e.g., the `tracker delete <id>` confirmation rationalization, SO R16 F4): a self-declared eventuality not anchored in the spec. The code is correct; the comment misrepresents what the design space allows.
+- **Classification:** Open — Raised to SO (this round) for code-comment cleanup. Carry-forward candidate, not a Layer 5 blocker.
+- **Proposed action:** Edit `src/lib.rs:489-490` to remove the `--description-contains` example, or replace it with a Layer-correct example (e.g., a hypothetical future `--created-after` filter framed as "if the spec is ever amended to add a new filter"). Edit the bd15a9d commit narrative if a follow-up amendment lands; otherwise note the carry-forward in CHANGELOG. No DESIGN.md change required — DESIGN.md is correct; the code comment is the deviation.
+- **Spec-creep evaluation:** Anticipatory creep at the comment level, which is the lowest-cost form to clear. The implementation itself is in scope.
+
+---
+
+#### Finding 2: Integration test docstring claims an in-progress setup issue exists, but the setup creates only open issues
+
+- **Dimension:** Dim 4 (Test obligations — test/comment fidelity)
+- **Severity:** Low
+- **Evidence:**
+  - `tests/layer5.rs:124-125`: "Note this exercises the non-default-status path: with no --status flag, effective_status is 'open' and only open issues participate; one of the setup issues is in-progress to confirm it is filtered out by the implicit status default."
+  - `tests/layer5.rs:127-159`: setup creates three issues (`Match all`, `Wrong priority`, `Wrong label`) via `tracker create` only — no `tracker status` invocation. All three start at default status `open`. None are in-progress.
+  - The test still passes because the AND-logic correctly excludes `Wrong priority` (low) and `Wrong label` (feature) from the `--priority high --label bug` filter result. The defect is in the docstring, not the assertion.
+- **Rationale:** A future maintainer reading the comment will look for an in-progress setup step that does not exist, then either add one (changing test semantics) or be confused. This is a small but real test-doc fidelity defect that was missed during code review of the Red Gate commit. It does not affect AC coverage — the test still establishes the AND-combination — but the stated intent ("confirm an in-progress issue is filtered out by the implicit status default") is not actually tested anywhere in `tests/layer5.rs`.
+- **Classification:** Open — coordination item for QE Review 13 (test-side ownership). SO surfaces it as a Dim 4 fidelity gap; QE may resolve directly without DESIGN.md or `TODO.md` changes.
+- **Proposed action:** Either (a) add a fourth setup issue and a `tracker status N in-progress` call so the comment matches the setup, or (b) trim the comment to drop the "one of the setup issues is in-progress" clause. Option (b) is the cheaper resolution; option (a) modestly strengthens the test by exercising the implicit-status-default path explicitly.
+
+---
+
+#### Finding 3: Manual testing checklist setup wording does not specify the `tracker status` step required to produce the `(done, high, bug)` issue
+
+- **Dimension:** Dim 1 (Spec coverage — checklist precision), Dim 9 (Assignment compliance — manual testing methodology)
+- **Severity:** Low
+- **Evidence:**
+  - `TODO.md:256`: "Setup: create four issues — `(open, high, bug)`, `(open, medium, bug)`, `(done, high, bug)`, `(open, high, feature)` — then run each filter combination and verify only the correct issue(s) appear".
+  - `tracker create` always produces `status: "open"` per DESIGN.md Feature 1 postcondition (line 26). To produce `(done, high, bug)` the user must also run `tracker status 3 done` after creating the third issue. The checklist instruction does not name this step.
+  - The commit `da0fd8d` ticks the box without elaboration. A literal reading of the wording — "create four issues" — matches a four-`tracker create` workflow, which would produce four open issues, not the `(done, ...)` mix the subsequent items assume.
+  - Compare prior layers' manual checklists (TODO.md Layer 2 / Layer 3 / Layer 4): each is explicit about each command needed. This Layer 5 entry is more terse and assumes the reader infers the status-change step.
+- **Rationale:** A manual testing checklist is the contract between developer and reviewer for the human-verification gate (DESIGN.md Testing Methodology line 373: "Each layer must be manually tested before the layer gate closes"). When the wording elides a required step, the gate becomes ambiguous: did the developer execute the implied step, or just the literal one? The actual filter-output expectations downstream of the setup (e.g., `--status open --priority high → issues #1 and #4 only` at TODO line 257) are only correct if issue #3 is `done`, so the elision is benign in practice — but the checklist as written is under-specified for a future reviewer reproducing the steps from scratch.
+- **Classification:** Open — Raised to SO for adjudication. The defect is in the checklist text, not in the implementation or the commit's ticking decision (which is consistent with the developer having executed the obvious additional `tracker status 3 done` step).
+- **Proposed action:** Amend `TODO.md:256` to spell out the setup explicitly. Suggested wording: "Setup: `tracker create "..." --priority high --label bug` (×1), `tracker create "..." --priority medium --label bug` (×1), `tracker create "..." --priority high --label bug` then `tracker status 3 done` (×1), `tracker create "..." --priority high --label feature` (×1)". Lowest-cost resolution; preserves the developer's existing tick and just records the reproducible command sequence.
+- **Spec-creep evaluation:** Documentation precision, not creep. Faithful elaboration of the existing checklist intent.
+
+---
+
+### Spec-creep audit (Dim 2 — additions not in DESIGN.md)
+
+Walked the Layer 5 diff (`921525d..HEAD`) for additions not described in DESIGN.md or TODO.md Layer 5:
+
+- **`issue_matches_filters` predicate** (`src/lib.rs:425-434`): directly required by DESIGN.md Feature 2 lines 63 + 321 (AND-combination) and the Layer 5 Red Gate plan (TODO.md lines 271-273). Not creep.
+- **`cmd_list` retain refactor** (single retain over the predicate, replacing three chained retains): structural refactor with unchanged behavior; the bd15a9d commit message documents the equivalence and the regression check confirms 135/135 passing. Per SO Review 16/17 the prior chained-retain form was already in place; consolidating is not new feature surface. Not creep.
+- **5 new unit tests** (`src/lib.rs:867-930`): all five exercise `issue_matches_filters` directly. Each maps to the Red Gate plan's two named unit tests (`filter_and_logic_all_must_match`, `filter_and_logic_all_present_returns_true`) plus three additional sub-cases that surface predicate-level corollaries (status-only matches anything, status mismatch rejects regardless of optional filters, label-match is case-sensitive). The three extras lean toward over-test by the strict TODO.md Red Gate plan, but each kills a distinct mutation (drop status conjunct, drop label conjunct case-sensitivity) and the marginal cost is trivial (~60 LOC across all five). Within tolerance for Dim 4; not creep.
+- **7 new integration tests** (`tests/layer5.rs`): 4 are named in the Red Gate plan (`list_two_filter_and_combination`, `list_three_filter_and_combination`, `list_no_match_shows_filter_message`, `list_default_does_not_show_filter_message`); 3 are sub-decompositions that split the AC pairs and the no-match cases. The Red Gate plan calls for 4; the actual count is 7. The extra three each exercise a distinct AC-pair (status×priority, status×label, priority×label, three-way) so the over-coverage is shaped to the AC count (8 ACs, 7 tests + 1 manual setup), not gold-plating. Cat B Red Gate disposition (see audit below) is honest. Slight over-test; well within tolerance.
+- **No new dependencies** in `Cargo.toml` or `Cargo.lock`. Confirmed unchanged by `git diff`.
+- **No Layer 6/7 surface leak.** `src/main.rs` enum is still `Create | List | Status`. No `show`, no `delete`, no `--description`, no `--help` polish, no color output.
+
+No spec creep detected at the implementation level. The single anticipatory comment in `cmd_list` referencing `--description-contains` is logged separately as Finding 1.
+
+---
+
+### Cat B Red Gate disposition audit
+
+The 7 integration tests in `tests/layer5.rs` are classified as "Cat B Red Gate deviations" because the AND-combination already worked at Phase 2a (the chained retains in `cmd_list` from Layers 3+4 produced the AND emergent behavior). The 5 unit tests on `issue_matches_filters` panic at Phase 2a (the `todo!()` stub) and pass at Phase 2b (the real predicate body), so they are the genuine Cat A Red Gate for Layer 5.
+
+Auditing for honesty:
+
+- **Is the Cat B claim factually correct?** Yes. The Phase 2a commit `7d1ca57` did not modify `cmd_list`; the integration tests at Phase 2a invoked the binary which still went through chained retains. The integration tests passed at Phase 2a — confirmed by the commit message's explicit statement and reproducible via `git checkout 7d1ca57 && cargo test --test layer5`.
+- **Is this consistent with prior layers' dispositions?** Yes. Layer 3's `create_without_priority_defaults_to_medium` and Layer 4's two Cat B deviations (commit `14bd219`) follow the same pattern: a layer's AC is genuinely emergent from a prior layer's implementation, the integration test is regression coverage rather than Red Gate gating, and the layer-specific genuine Red Gate is a unit-test-level abstraction that didn't exist before. Same shape here.
+- **Does it paper over a Phase 2a violation?** No. A Phase 2a violation would be: a behavior named in Layer 5's ACs that exists at Phase 2a but does not have a unit test failing against the Phase 2a state. Here, every AC pair has a Phase-2a-failing unit test against `issue_matches_filters`, which is the abstraction Layer 5 introduces. The integration tests are *additional* regression coverage, not the only assertion of the AC.
+- **Could the Cat A unit tests have been written without introducing the predicate?** Only by testing through `cmd_list` (an integration shape) or by inlining the AND-logic as a free function the tests could call. Either alternative would either degrade testability or duplicate the chained-retain logic in a function-body extracted-from-`cmd_list` form — which is exactly what Phase 2b does. So the predicate extraction is the natural Cat A scaffold, and committing it as a `todo!()` stub at Phase 2a is the correct Red Gate shape.
+
+The Cat B disposition is honest. No Phase 2a violation.
+
+---
+
+### Hallucinated
+
+*(none this round)*
+
+### Backlogged
+
+*(none this round)*
+
+### Dismissed
+
+*(none this round — F1 / F2 / F3 are real low-severity findings, not hallucinations)*
+
+### Open
+
+- **F1** (anticipatory `--description-contains` comment) — code-comment cleanup; coordination with SE.
+- **F2** (test-comment claims in-progress setup that doesn't exist) — coordination with QE.
+- **F3** (manual testing checklist setup elides `tracker status` step) — SO doc-only fix to `TODO.md`.
+
+### Carry-forward (from prior rounds)
+
+- **F8 (Review 15)** — `Cargo.toml` `repository` field — Resolved post-R17 (the file now has `repository = "https://github.com/magnificentlycursed/guild-portfolio"` per R17 closure entry). Status: **Resolved**, retroactively. No action this round.
+
+---
+
+### Summary
+
+3 Open findings, all Low severity. 0 Hallucinated. 0 Dismissed. 0 Backlogged. 0 Approved deviations.
+
+The Layer 5 implementation matches all 8 acceptance criteria with passing tests; the Cat B Red Gate disposition is honest and consistent with prior-layer practice; no new dependencies; no Layer 6/7 surface leakage; manual testing checklist closed. The compliance table is clean at the implementation level.
+
+The three findings are documentation-class:
+- F1 is an anticipatory code comment that names an out-of-scope feature.
+- F2 is a test docstring that describes a setup step that doesn't exist.
+- F3 is a manual testing checklist that elides a required `tracker status` step.
+
+None block Layer 5 closure. All are within reach of a single-PR cleanup. F1 + F2 are SE/QE coordination items; F3 is SO-authority (TODO.md).
+
+**Sycophancy check (self-applied):** A clean Layer 5 review is the failure mode the cold-session prompt warns about. I tested whether the three findings are real by trying to dismiss each:
+
+- **F1 dismissal attempt:** "The comment is harmless aspirational future-proofing." Counter: the spec explicitly excludes the feature ("filtering is by exact-match status, priority, and label only"). A comment that names an excluded feature as a Layer 6 expectation contradicts the spec's binding text. The bd15a9d commit message ratifies the same direction, doubling the signal. Real finding.
+- **F2 dismissal attempt:** "Test docstrings are low-stakes; the test still asserts the right behavior." Counter: the test is correct; the docstring is wrong. A future maintainer reading the docstring will look for the in-progress setup step that doesn't exist and either change the test (regressing coverage) or be confused. The cost to fix is one line; the cost to leave is one future code-review distraction. Real finding, low severity.
+- **F3 dismissal attempt:** "Manual testing was executed correctly; the developer obviously knew the `tracker status` step was implied." Counter: the manual checklist is the contract between developer and external reviewer for the gate-close. The developer's tacit knowledge does not document the gate. Compare prior layers' checklists, which spell out each step explicitly — the Layer 5 wording is genuinely terser. Real finding, low severity.
+
+Each finding survived the dismissal test. The clean compliance table is genuine; the three findings are the residue.
+
+**Coordination:**
+- **Software Engineer (SE Review 13):** F1 is the code-side change (one comment edit at `src/lib.rs:489-490`). SE may resolve directly; no DESIGN.md change required.
+- **Quality Engineer (QE Review 13):** F2 is the test-side change. QE may resolve directly via either (a) trim the comment or (b) add the missing setup step. SO has no preference; QE owns the call.
+- **Solution Architect (SA Review 11):** SA may have an architectural opinion on whether the predicate extraction is a valuable layer 7 prep step (it co-locates the AND-logic for the Layer 7 color refactor). Not a finding for this round; flagged for SA awareness.
+- **VDD-IAR Alignment (VDD-IAR Review 13):** F3 is a manual-testing-process datum — the checklist precision norm is in VDD-IAR's wheelhouse. Recommend VDD-IAR's pass note whether the Layer 5 checklist precision (terser than Layers 2-4) is an isolated deviation or a drift the project should correct.
+- **Director (SO authority):** F3 requires a `TODO.md` edit. SO is the only domain that may edit `TODO.md` directly per CLOSURE-PROTOCOL.md authority. Recommended action: in the Round-2 closure pass, edit the Layer 5 manual checklist setup line to enumerate the four-step command sequence including the `tracker status 3 done` step.
+
+The Layer 5 implementation is in spec compliance and ready to merge after the documentation cleanup above. No DESIGN.md amendments required this round.
+
+---
+
+## Review 19 — 2026-05-07 00:39Z
+
+**Round:** SO Review 19 (Round-2 closure for Layer 5 — Compound Filtering)
+**Scope:** Verify Round-1 inline findings (F1, F2, F3) are resolved by commit `7f9bae4`. No new substantive review pass; this is a warm closure-verification per CLOSURE-PROTOCOL Section 5 step 3.
+**Session context:** Director-orchestrated warm-resolution session; not adversarial-cold by design.
+
+### Round-1 finding closures
+
+- **F1 (anticipatory `--description-contains` comment):** **Resolved.** `src/lib.rs:489-497` now reads "any new filter the spec is amended to add" with an explicit DESIGN.md "Out of Scope" citation. The prior anticipated-Layer-6-feature framing is gone; no out-of-scope feature is named. Verified by reading the post-`7f9bae4` diff.
+- **F2 (test-comment claims in-progress setup that does not exist):** **Resolved.** `tests/layer5.rs:121-125` docstring trimmed to drop the false in-progress claim; replaced with an accurate description of the AND-combination across the priority and label filters under the implicit `--status open` default. Test assertions unchanged; 7/7 Layer-5 integration tests still pass.
+- **F3 (manual checklist setup elides `tracker status` step):** **Resolved.** `TODO.md:256` rewritten to enumerate each `tracker create` invocation and the `tracker status 3 done` step required to produce the `(done, high, bug)` issue. Matches the explicitness of Layers 2-4 manual checklists.
+
+### Hallucinated / Backlogged / Dismissed
+
+*(none this round)*
+
+### Open
+
+*(none from SO domain. SA R11 F1 — rendering half of `cmd_list` extraction — remains the only Layer 5 Open finding across the suite, deferred to a focused pre-Layer-7 PR per SA R10 / SA R11 disposition. SO has no objection to that deferral.)*
+
+### Summary
+
+3/3 Round-1 SO findings Resolved by commit `7f9bae4`. 0 new findings this round. Layer 5 SO compliance is closed. Layer 5 ready to merge from the SO lens once VDD-IAR R14 confirms the suite-level merge gate.
+
+**Coordination:** *(none — closure pass)*

--- a/issue-tracker-cli/iterative-adversarial-refinement/VDD-IAR-ALIGNMENT-REVIEW.md
+++ b/issue-tracker-cli/iterative-adversarial-refinement/VDD-IAR-ALIGNMENT-REVIEW.md
@@ -1441,3 +1441,279 @@ Only this log appended.
 
 ---
 
+## Review 13 — 2026-05-07 00:27Z
+
+**Round:** VDD-IAR Alignment Review 13 (Layer 5 — Compound Filtering — process audit, post-implementation, pre-IAR)
+
+**Scope:** Layer 5 process compliance from the merge of #16 (Layer 4 close at `3c7d65d`) through Layer 5 implementation-complete at `da0fd8d`. The three Layer 5 commits in scope are `7d1ca57` (Phase 2a Red Gate), `bd15a9d` (Phase 2b implementation), `da0fd8d` (manual testing closure). Inputs: `DESIGN.md` Feature 2 (lines 51-82), `TODO.md` Layer 5 (lines 239-275), `tests/layer5.rs` (Red Gate diff at 7d1ca57), `src/lib.rs` Layer 5 unit tests + `issue_matches_filters` predicate (Red Gate stub at 7d1ca57 → Phase 2b body at bd15a9d), `iterative-adversarial-refinement/CLOSURE-PROTOCOL.md`, prior VDD-IAR Reviews 11-12, prior carry-over findings (SA R9 F1 / SE R11 F2 — `cmd_list` extraction; QE R11 F5 — Layer 5 compound-filter test marker; TW R7 F5 — PROCESS.md retrospectives).
+
+**Session note:** Cold-session per `prompts/review-session.md`. Parallel-batch peer with SO 18, SA 11, QE 13, SE 13. Adversarial framing intact. This reviewer did not author Layer 5 commits and did not participate in Layer 4 IAR. Running last in the merge-gate sequence per `README.md` § Sequencing. Independent verification: I re-read `tests/layer5.rs` and `src/lib.rs` `mod tests` against commit `7d1ca57` content directly (via `git show 7d1ca57 -- src/lib.rs`) rather than against the HEAD post-impl state — the stub was `todo!()` with `#[allow(dead_code)]` at Red Gate time, the predicate body landed in `bd15a9d` with the `#[allow(dead_code)]` removed.
+
+**Program phase:** Phase 1. Crosslink not introduced; dim 11 N/A. Governing methodology: `apprentice-onboarding/02-the-methodology/01-how-we-build.md` (process); `iterative-adversarial-refinement/CLOSURE-PROTOCOL.md` (project-scoped closure mechanics).
+
+**Regression check on Reviews 11-12:** Review 12 closed Layer 4 with Conditional GO pending TW R7 F5 (PROCESS.md retrospectives). Commit `a226d88` ("PROCESS.md Layer 1-4 developer reflections", 2026-05-06 16:30:27 -0700) closed that gate; merge `3c7d65d` (16:35:20) followed; Layer 5 Red Gate `7d1ca57` (17:04:48) opened ~30 minutes later. Layer 4 gate closure → Layer 5 open ordering is clean.
+
+---
+
+### Layer 5 commit-pattern audit
+
+| Commit | Time | Phase signal |
+|---|---|---|
+| `7d1ca57` Layer 5 Red Gate — compound-filter tests + stub | 2026-05-06 17:04:48 -0700 | Phase 2a: 7 integration tests in `tests/layer5.rs` + 5 unit tests in `src/lib.rs#tests` + `issue_matches_filters` `todo!()` stub with `#[allow(dead_code)]`; Cat B integration deviations explicitly named in commit message |
+| `bd15a9d` Layer 5 implementation — compound-filter predicate | 2026-05-06 17:06:16 -0700 | Phase 2b: stub body replaced with AND predicate; `cmd_list`'s three retains collapsed to one; `#[allow(dead_code)]` removed; TODO.md AC checkboxes flipped to `[x]` |
+| `da0fd8d` Layer 5 manual testing complete | 2026-05-06 17:19:50 -0700 | Manual checklist 6/6 ticked after human verification |
+
+Phase 2a → Phase 2b gap: 1 minute 28 seconds. Boundary is verifiable from history: `git show 7d1ca57 -- src/lib.rs` shows `todo!("Layer 5: extract AND-logic predicate from cmd_list's chained retain calls")` and `let _ = (issue, status, priority, label);` arg-binding to placate `-D warnings`. `git show bd15a9d -- src/lib.rs` shows that exact stub block replaced with `issue.status == status && priority.is_none_or(|p| issue.priority == p) && label.is_none_or(|l| label_matches(&issue.labels, l))` and `cmd_list`'s three `retain` calls collapsed to one over the predicate. The Phase 2a → Phase 2b commit boundary is the right pattern — every file change after `7d1ca57` is implementation; no implementation exists in `7d1ca57` itself.
+
+---
+
+### Resolved
+
+*(none — VDD-IAR owns its log + may amend `CLOSURE-PROTOCOL.md`; no process-change artifact was applied this session)*
+
+---
+
+### Open
+
+*(none — see Dismissed for the per-dimension findings)*
+
+---
+
+### Dismissed
+
+**Finding 1 — Design before code (Dim 1)**
+
+DESIGN.md Feature 2 (`DESIGN.md:51-82`) defines the compound-filter contract before Layer 5 began: line 63 — "**Multiple filters:** `--status`, `--priority`, and `--label` are AND-combined. An issue must match all provided filters to appear." Lines 71-72 define the no-match empty-state messages: `No issues match the given filters.` for filtered-but-no-match and `No open issues. Nice work!` for default-view-empty. Edge-cases section earlier in DESIGN.md and the Testing Methodology section (line 362 — "Issue filtering: each filter independently; AND-combination of two and three filters; no-match case") all anchor Layer 5 in the spec. Layer 5 implementation matches: (a) the predicate is AND-combined; (b) the no-match message routes to stderr (per Feature 2 stderr contract); (c) the default-view-non-empty case shows results without the filter message. No DESIGN.md edits in any Layer 5 commit (`git show 7d1ca57 bd15a9d da0fd8d --stat` shows `src/lib.rs`, `tests/layer5.rs`, `TODO.md` only — DESIGN.md untouched). Spec-before-code temporal ordering is intact and authority over `DESIGN.md` was respected.
+
+**Classification:** Dismissed.
+
+---
+
+**Finding 2 — Layered decomposition (Dim 2)**
+
+`TODO.md` Layer 5 section (lines 239-275) had a goal statement, 8 acceptance criteria, 6 manual testing checklist items, a Red Gate test plan listing 4 integration + 2 unit tests, and an IAR domain assignment (SO, SA, QE, SE, VDD-IAR Alignment) — all in place before Layer 5 implementation began (the TODO.md plan predates `7d1ca57`'s only TODO.md edits, which are checkbox flips). Layer 5 scope (compound filtering only) was respected: nothing from Layer 6 (description / show / delete) leaked into Layer 5 commits. `git show bd15a9d -- src/lib.rs` shows changes confined to `issue_matches_filters` predicate body and `cmd_list`'s three-retain → one-retain refactor; no `--description`, no `cmd_show`, no `cmd_delete` paths added. The Red Gate test plan in TODO.md called for 4 integration + 2 unit tests; what landed was 7 integration + 5 unit tests — over-delivery on coverage, not under-delivery on scope. Specifically the implementation-as-shipped includes `list_status_and_priority_filter_and_combination`, `list_status_and_label_filter_and_combination`, `list_priority_and_label_filter_and_combination` (the three two-filter pairs explicitly), `list_three_filter_and_combination`, two `list_compound_*_no_match_shows_filter_message` tests, and `list_default_view_with_open_issues_does_not_show_filter_message`; on the unit side the 5 tests cover all-present, all-must-match (with three subcases for each conjunct as the odd-one-out), status-only-wildcard, status-mismatch-rejects, and case-sensitive-label. Layer scope clean.
+
+**Classification:** Dismissed.
+
+---
+
+**Finding 3 — Layer gate compliance (Dim 3)**
+
+Layer 4 closure: VDD-IAR Review 12 issued Conditional GO pending TW R7 F5 (PROCESS.md retrospectives). Commit `a226d88` ("issue-tracker-cli: PROCESS.md Layer 1-4 developer reflections", 2026-05-06 16:30:27 -0700) closed the developer-only gate. Merge `3c7d65d` (Layer 4 → main, 16:35:20) followed. Layer 5 first commit `7d1ca57` opened at 17:04:48 — 29 minutes after the Layer 4 merge. The branch was started from a state where Layer 1-4 gates were closed. No Layer 5 commit modifies Layer 1-4 code-paths in a way that suggests carry-over from Layer 4 IAR — `git show 7d1ca57 bd15a9d --stat` shows `src/lib.rs`, `tests/layer5.rs`, `TODO.md` only; no Layer 4 IAR-finding-resolution work bled into Layer 5. The branch name `issue-tracker-cli-compound-filtering` matches the layer scope. Layer-gate compliance clean.
+
+**Classification:** Dismissed.
+
+---
+
+**Finding 4 — Red Gate boundary (Dim 4 — CRITICAL)**
+
+This is the central question for Layer 5 IAR. Direct evidence from `git show 7d1ca57 -- src/lib.rs`:
+
+```
++#[allow(dead_code)]
++fn issue_matches_filters(
++    issue: &Issue,
++    status: &str,
++    priority: Option<&str>,
++    label: Option<&str>,
++) -> bool {
++    let _ = (issue, status, priority, label);
++    todo!("Layer 5: extract AND-logic predicate from cmd_list's chained retain calls")
++}
+```
+
+`cmd_list` at `7d1ca57` is **unchanged** — it still calls the three sequential `retain` blocks; the new `issue_matches_filters` is unreached, hence the `#[allow(dead_code)]`. The 5 unit tests in `mod tests` exercise `issue_matches_filters` directly and would panic at runtime with `not yet implemented: Layer 5: extract AND-logic predicate...`.
+
+`git show bd15a9d -- src/lib.rs` then replaces the stub body with the real AND predicate, removes the `#[allow(dead_code)]`, and refactors `cmd_list` to a single `retain(|i| issue_matches_filters(i, ...))` call. The Phase 2b commit is purely the implementation of the previously-stubbed predicate plus the call-site adoption.
+
+The 7 integration tests committed in `7d1ca57` are explicitly disclosed as **Cat B Red Gate deviations** in the commit message:
+> 7 integration tests pass as Cat B Red Gate deviations: the AND-combination is an emergent property of cmd_list's chained retain() calls (Layer 3 added --priority retain, Layer 4 added --label retain), so the CLI behavior was implemented incrementally rather than as a single Layer 5 change.
+
+This is the right disclosure pattern. The implementation prompt warns: "If implementation begins before this commit, the commit history cannot distinguish test-first from test-after, and VDD-IAR Alignment dim 4 cannot be verified." For Cat B, the implementation predates the test in a specific, documented way (Layers 3 and 4 added the retains in earlier Red Gates that did fail-then-pass for their own scope) and the Layer 5 test is regression coverage of an emergent property, not the Red Gate primary signal. The Red Gate primary signal is the 5 unit tests on `issue_matches_filters`, which **did fail at `7d1ca57`** by `todo!()` panic. Same disposition as Layer 3's `create_without_priority_defaults_to_medium` and Layer 4's two Cat B deviations (`create_without_labels_stores_empty_array`, `list_shows_none_for_no_labels`); the Cat B precedent is established and applied consistently.
+
+The adversarial probe in the review brief — "is the Cat B label honest, or is it papering over a Phase 2a violation?" — answers cleanly. A papering-over would look like: 7 integration tests AND the predicate body in `7d1ca57`, then a no-op refactor in `bd15a9d` purely to make the commit history look two-phase. Two falsifiable predictions of that scenario: (a) `bd15a9d`'s `src/lib.rs` diff would be cosmetic (rename / move / no body change); (b) the test count in `bd15a9d` would not have changed (no new tests would be needed, since the test-count would already be set in 7d1ca57). Both predictions fail: (a) `bd15a9d` shows substantive body change (`todo!()` → real predicate; three retains → one retain) plus removal of `#[allow(dead_code)]` plus a `cmd_list` call-site refactor — none of which are cosmetic; (b) the test count in `7d1ca57` already includes everything Layer 5 ships, **and** the failing assertion at Red Gate time (`todo!()` panic at any `issue_matches_filters` call) is a real signal that the predicate did not exist. The `#[allow(dead_code)]` annotation in 7d1ca57 is itself the strongest tell that the Phase 2a → 2b boundary is real: a performative Red Gate would not need to silence a dead-code warning, because the function would already be called.
+
+**Classification:** Dismissed. Red Gate boundary integrity verified.
+
+---
+
+**Finding 5 — Test discipline (Dim 5)**
+
+Test-first ordering at the commit-pattern level is intact (Finding 4). The 5 unit tests and the `todo!()` stub were committed together in `7d1ca57`; the tests would have failed against the stub by `todo!()` panic. Phase 2b (`bd15a9d`) added zero new tests to the suite — it filled in only the stub body and the `cmd_list` refactor; this is the right pattern (Phase 2b is implementation, not test addition; if a test were missing it would be added in a separate commit per `prompts/implementation.md` step 2).
+
+The 7 integration tests are correctly disclosed as Cat B Red Gate deviations in the commit message. They are not mislabeled as Cat A. The Cat B framing matches the prior-layer precedent established in Layer 3 (`create_without_priority_defaults_to_medium`) and Layer 4 (two integration tests for label defaults). The pattern across Layers 3-5 is now consistent: when a Layer's behavior is partly emergent from the chained accretion of prior-layer Red Gates, the Layer's integration tests for the emergent behavior pass at Red Gate time and are labeled Cat B with an explicit prior-Red-Gate citation.
+
+The QE R11 F5 marker — "Layer 5 must produce `list_status_priority_label_compound_AND_filter` (or equivalent) covering the spec line 313 example" — is satisfied by `tests/layer5.rs:186` `list_three_filter_and_combination`, which is exactly the spec line 313 case (`--status open --priority high --label bug` AND-logic; only matching issue present). The deferral lands cleanly. (QE Review 13 owns the formal closure of QE R11 F5; this VDD-IAR finding records that the marker was honored at the Red Gate test plan level.)
+
+**Classification:** Dismissed.
+
+---
+
+**Finding 6 — Human verification (Dim 6)**
+
+Commit `da0fd8d` ("Layer 5 manual testing complete") flipped all 6 Manual Testing Checklist items in TODO.md to `[x]`. The commit message body lists each of the 6 scenarios verified:
+- Setup with four issues spanning all status × priority × label combinations
+- Two-filter AND (`--status open --priority high`)
+- Three-filter AND (`--status open --priority high --label bug`)
+- No-match from filters → `No issues match the given filters.`
+- Default view with open issues → no empty-state message
+- All-done state → `No open issues. Nice work!` (not the filter message)
+
+This satisfies the dim-9-as-applied-at-merge standard from CLOSURE-PROTOCOL.md Section 6 item 7 (manual testing implicit in the merge gate). The narrative density is slightly thinner than the Layer 4 precedent commit `b0a3789`, which used "Verified in terminal: <observed behaviors list>" framing — Layer 5's commit message reads more like a restatement of the checklist than an enumeration of observed outputs. However, the commit message is unambiguous that "All 6 Manual Testing Checklist items in TODO.md flipped to `[x]` after human verification of compound-filter behavior at the CLI" and lists each scenario with the expected result. Two reviewers would agree the human ran the binary against the 6 scenarios; the box ticks plus the per-scenario enumeration plus the explicit "after human verification" statement clear the bar. (For Layer 6+, the director may want to standardize on the Layer-4 "Verified in terminal: <observed behaviors>" framing, which is slightly stronger evidence than scenario-restatement; this is a polish suggestion, not a dim-6 violation.)
+
+The manual testing closure is a separate commit from the implementation, mirroring the Layer 3 (`6f7fd46`) and Layer 4 (`b0a3789`) precedents. The implementation commit `bd15a9d` correctly does NOT tick the manual checklist — its commit message even says "The Manual Testing Checklist is intentionally left unchecked — per VSDD Phase 2 completion criteria, manual testing requires human verification and is not satisfied by automated tests." This is the right discipline (the implementation agent doesn't claim to have verified manually; the human director's separate commit does).
+
+**Classification:** Dismissed. (Polish note recorded for future layers re: Layer-4-style "Verified in terminal:" framing; not a finding.)
+
+---
+
+**Finding 7 — IAR iteration / carry-over closure (Dim 7)**
+
+Three Layer 4 carry-over findings entered Layer 5 with named-target dispositions. Verifying each:
+
+- **SA R9 F1 / SE R11 F2 — `cmd_list` extraction.** Disposition at end of Review 12: "Deferred to a focused PR before Layer 7 with named target." Layer 5 status: still Deferred. Layer 5 did NOT do the full `cmd_list` extraction (no `format_header_row`, `format_issue_row`, `filter_issues` helpers; no module-level column-width constants). It did extract a single named predicate (`issue_matches_filters`) which is a partial step toward the SA-9-F1 pattern but does not discharge the full finding. The deferral target (focused PR before Layer 7) remains in effect. This is in-policy: a Deferred finding with a named target may persist across the layer immediately following the deferral, as long as the target layer remains the commitment. Not a violation; the deferral was not reset to Layer 5 and was not silently dropped.
+
+- **QE R11 F5 — compound-filter test.** Disposition: "Open / Deferred to Layer 5" with the explicit marker that "Layer 5 must produce `list_status_priority_label_compound_AND_filter` (or equivalent)". Layer 5 status: marker honored at test-plan level by `tests/layer5.rs:186` `list_three_filter_and_combination`. QE Review 13 (running in parallel with this VDD-IAR review) owns the formal Resolved transition; from VDD-IAR Alignment's perspective, the deferral landed where it was committed to land.
+
+- **TW R7 F5 — PROCESS.md retrospective placeholders.** Disposition at Review 12: "the only Open finding gating Layer 4 merge after Round 2." Closed by commit `a226d88` before Layer 4 merge. Not a Layer 5 carry-over.
+
+- **Other prior-layer findings:** Review 12 listed 14 Resolved + 1 Accepted Risk + 5 Deferred (Layer 7 polish + cmd_list extraction + Layer 5 compound-filter test). The Layer 7 polish items (UX R6 F2/F3, TW R7 F6) remain Deferred to Layer 7 with named target — Layer 5 did not action them, which is correct (they are not Layer 5 scope).
+
+No deferred-then-silently-dropped pattern. No carry-over finding spilled into Layer 5 in a way that would have required Layer 5 to absorb Layer 4 IAR work. The Section 5 cadence (cold-batch → warm-resolution → SO-adjudication → VDD-IAR-closure) ran cleanly for Layer 4 and Layer 5 opens with all prior-layer process bookkeeping in terminal states.
+
+**Classification:** Dismissed.
+
+---
+
+**Finding 8 — Process artifact integrity / performative-Red-Gate inverse test (Dim 8)**
+
+The review brief asks: "How would a performative Red Gate look different?" Applying the inverse test:
+
+1. **Performative tell #1: implementation present in 7d1ca57.** Inverse: actual `7d1ca57` shows `todo!()` body and `#[allow(dead_code)]` annotation. ✓ inverse holds.
+2. **Performative tell #2: 7d1ca57 commit-message claim of "tests fail" without runnable evidence.** Inverse: actual `7d1ca57` commit message names each of the 5 unit tests by name and states "todo!() panics — predicate not implemented" as the failure mode; commit also names 7 integration tests as Cat B with explicit prior-Red-Gate citation (Layers 3 and 4). ✓ inverse holds (the failure mode is concrete and reproducible by reverting `bd15a9d`).
+3. **Performative tell #3: bd15a9d is a no-op refactor (rename/move only) so the commit pair "looks" two-phase.** Inverse: actual `bd15a9d` shows substantive body change (stub → real predicate, three retains → one retain, dead-code allow removed). ✓ inverse holds.
+4. **Performative tell #4: integration tests labeled Cat A despite emergent-from-prior-layer behavior.** Inverse: actual `7d1ca57` explicitly labels the 7 integration tests Cat B and cites the prior-Red-Gate provenance (Layer 3 priority retain; Layer 4 label retain). ✓ inverse holds.
+5. **Performative tell #5: manual testing closure batched into the implementation commit.** Inverse: manual testing closure is a separate commit (`da0fd8d`), 13 minutes after implementation, with explicit human-verification language in the message. ✓ inverse holds.
+
+All five inverse tests pass. The Layer 5 commit pattern is the real-Red-Gate pattern, not the performative one. The `#[allow(dead_code)]` annotation in `7d1ca57` is the strongest single artifact: it is forced by the compiler in `-D warnings` mode when an unused private function exists, and a performative Red Gate (where the function is called) would not need it. Removing the annotation in `bd15a9d` is the symmetric tell that the call-site refactor is what made the function reachable.
+
+**Classification:** Dismissed.
+
+---
+
+### Hallucinated
+
+*(none)*
+
+---
+
+### Process integrity audit
+
+Authority chain for Layer 5 commits (per `CLOSURE-PROTOCOL.md` Section 1):
+
+| File | Authority | Layer 5 modifier | OK? |
+|---|---|---|---|
+| `tests/layer5.rs` (new) | QE primary; SE for parity with code | Co-authored at Red Gate (`7d1ca57`); test plan in `TODO.md` is the authority signal | ✓ |
+| `src/lib.rs` (Layer 5 unit tests + predicate) | SE primary (impl); QE primary (tests) | Both classes co-authored in Red Gate + Phase 2b commits | ✓ |
+| `TODO.md` (AC + manual checklist tick-throughs) | SO (scope); director (sequencing) | Checkbox flips by implementation agent (AC) + director (manual) — checkbox flips are not scope changes; in-policy | ✓ |
+| `DESIGN.md` | SO only | Not modified in any Layer 5 commit | ✓ |
+| `CHANGELOG.md` | Any domain that produced the change | Not yet modified for Layer 5 (will be added during Layer 5 IAR Round 2 / merge prep, mirroring Layer 4 cadence) | acknowledged |
+| `iterative-adversarial-refinement/<DOMAIN>-REVIEW.md` | The owning domain only | Each domain's Layer 5 entry will be its own (this round runs in parallel with SO 18 / SA 11 / QE 13 / SE 13) | ✓ in progress |
+
+Authority chain clean for the implementation phase. The CHANGELOG entry for Layer 5 is acknowledged as a pending merge-prep artifact (per the Layer 4 precedent: SO authored the Layer 4 CHANGELOG entry during Round 2 close); not a Layer-5-Phase-2-scope item.
+
+The Section 5 cadence has run through step 1 (cold-batch parallel review batch — this round, with SO 18 / SA 11 / QE 13 / SE 13 / VDD-IAR 13). Steps 2-4 (warm-resolution, SO-adjudication, final VDD-IAR closure) are downstream and are not in the scope of this round. This round's role is to verify the **Phase 2** process (Red Gate boundary, test discipline, manual testing closure, layer scope, carry-over disposition) before the IAR cadence produces findings to close.
+
+---
+
+### Summary
+
+Layer 5 process compliance is **clean across all eight evaluated dimensions**. All findings dismissed.
+
+- **Dim 1 (Design before code):** ✓ DESIGN.md Feature 2 line 63 / 71-72 / 313 (edge cases) defined the AND-combination contract before Layer 5 began. No DESIGN.md edits in Layer 5.
+- **Dim 2 (Layered decomposition):** ✓ Layer 5 scope respected; no Layer 6 leak; over-delivery on test coverage (7 integration + 5 unit vs. 4 + 2 planned).
+- **Dim 3 (Layer gate compliance):** ✓ Layer 4 closed by `a226d88` before merge `3c7d65d`; Layer 5 opened 29 minutes after the merge.
+- **Dim 4 (Red Gate boundary — CRITICAL):** ✓ `7d1ca57` contains `todo!()` stub + `#[allow(dead_code)]` + 5 failing unit tests + 7 Cat-B-disclosed integration tests; `bd15a9d` substantively replaces the stub body and removes the dead-code allow. Inverse tests against the performative-Red-Gate hypothesis all hold.
+- **Dim 5 (Test discipline):** ✓ Tests committed in Red Gate; Phase 2b adds zero tests; Cat B disclosure honest; QE R11 F5 marker satisfied by `list_three_filter_and_combination`.
+- **Dim 6 (Human verification):** ✓ `da0fd8d` ticks all 6 manual checklist items with per-scenario enumeration in commit message. Slightly thinner narrative than Layer 4's "Verified in terminal:" framing — polish note for Layer 6+ but not a violation.
+- **Dim 7 (IAR iteration):** ✓ All three relevant carry-overs in expected dispositions. SA R9 F1 / SE R11 F2 still Deferred to focused-PR-before-Layer-7 (Layer 5 did NOT silently absorb the work). QE R11 F5 marker honored. TW R7 F5 closed before merge.
+- **Dim 8 (Process artifact integrity):** ✓ Five inverse tests against the performative-Red-Gate hypothesis all hold. The `#[allow(dead_code)]` annotation in `7d1ca57` plus its removal in `bd15a9d` is the strongest single artifact that the boundary is real.
+
+**Sycophancy guard self-applied.** The most adversarial reading of Layer 5 is: "the AND-combination already worked at end-of-Layer-4 (the chained retains already AND-combined); Layer 5 added a refactor and called it a Red Gate." This reading is the Cat B framing the developer themselves disclosed in the commit message. The honest question is whether the Cat B framing is enough — does Layer 5 contain any Red Gate primary signal? Yes: the 5 unit tests on `issue_matches_filters` failed at Red Gate by `todo!()` panic, in a way that is both compiler-verifiable and reproducible by reverting `bd15a9d`. The unit tests are the Red Gate primary signal; the integration tests are regression coverage of the emergent behavior. This is the right shape for a "refactor + extract predicate" layer that lands on top of behavior accreted in prior Red Gates.
+
+A second adversarial reading: "Layer 5's manual testing commit message is a restatement of the checklist, not observation evidence — could it be self-reported without actually running the binary?" The commit message language ("after human verification of compound-filter behavior at the CLI") is explicit about human verification; the per-scenario enumeration includes the expected output messages (`No issues match the given filters.`, `No open issues. Nice work!`). A reviewer who wanted to falsify could ask the director to demonstrate `tracker list --status open --priority high --label bug` against a fixture, but this is independent verification, not a Phase-2 process finding. The Phase-2 standard is: did the human run the binary and tick the checklist? The commit attests to yes. Not a finding.
+
+---
+
+### Coordination
+
+- **VDD-IAR Alignment Round 13 of the cold-batch peers (SO 18, SA 11, QE 13, SE 13, VDD-IAR 13).** Each domain runs cold per `prompts/review-session.md`. This VDD-IAR pass evaluates the artifact set as it stands at start-of-round.
+- **No findings raised to other domains.** This round produces zero Open findings; cross-domain coordination is N/A.
+- **Carry-over watch for Layer 5+ Round 2 (if needed):** SA R9 F1 / SE R11 F2 (cmd_list extraction) remain Deferred to focused-PR-before-Layer-7. Layer 5's predicate extraction is a partial step toward that target but does not discharge the full finding. The director should track when the focused PR lands; the finding's named-target deadline is "before Layer 7 begins," and Layer 6 is still ahead of that.
+- **CHANGELOG Layer 5 entry is acknowledged as pending merge-prep.** Per Layer 4 precedent (SO Review 17 authored the Layer 4 CHANGELOG entry during Round 2 close), the Layer 5 CHANGELOG entry will be authored during the merge-prep cadence. Not a Phase-2-scope finding.
+
+---
+
+### Merge-gate verdict
+
+**This round is the Phase-2 process audit, not the merge gate.** Layer 5 has not yet completed the IAR cadence — only step 1 of `CLOSURE-PROTOCOL.md` Section 5 (cold-session parallel review batch) is in progress, with SO 18 / SA 11 / QE 13 / SE 13 / VDD-IAR 13 running together. Steps 2-4 (warm-resolution if findings exist, SO-adjudication if spec questions arise, final VDD-IAR closure) are downstream.
+
+VDD-IAR's verdict on the Phase-2 process is unconditional: **GO on Phase-2 process compliance**. Layer 5's design-before-code, layered decomposition, layer gate compliance, Red Gate boundary, test discipline, human verification, IAR iteration, and process artifact integrity are all clean. If the round-1 cold-batch from SO/SA/QE/SE produces real findings, the merge gate will require a Round 2 per Section 5 — but the Phase-2 process record itself is sound. **Refinement may continue on substantive (non-process) dimensions.**
+
+If SO/SA/QE/SE Round 1 produces zero real findings (or only hallucinated ones), the merge gate may close after a final VDD-IAR closure round (Review 14) verifying the gate items in `CLOSURE-PROTOCOL.md` Section 6. If they produce real findings, the standard Section-5 cadence applies (warm-resolution → SO-adjudication if needed → round-2 cold-batch → Review 14 closure).
+
+This round closes for VDD-IAR Alignment as a domain. The merge-gate decision is downstream of the substantive-domain rounds running in parallel.
+
+---
+
+### Files modified
+
+Only this log appended.
+
+---
+
+## Review 14 — 2026-05-07 00:43Z
+
+**Round:** VDD-IAR Review 14 (Round-2 merge-gate closure for Layer 5)
+**Scope:** Verify Round-1 cold-batch IAR cadence completed, Round-2 inline fixes commit `7f9bae4` closes the substantive-domain Round-1 findings, and the residual carry-forward (SA R11 F1) has a named future-layer disposition.
+
+### Refinement loop verification
+
+Round-1 cold-batch (SO 18 / SA 11 / QE 13 / SE 13 / VDD-IAR 13) produced 5 substantive findings:
+
+| Finding | Domain | Severity | Resolution path | Status post-`7f9bae4` |
+|---|---|---|---|---|
+| SO R18 F1 — anticipatory `--description-contains` comment | SO | Low | Code comment edit | Resolved |
+| SO R18 F2 — test docstring claim mismatch | SO | Low | Test docstring trim | Resolved |
+| SO R18 F3 — manual checklist setup elides `tracker status` step | SO | Low | TODO.md amendment | Resolved |
+| QE R13 F1 — `&&`→`\|\|` between optional conjuncts (defense-in-depth) | QE | Low | New unit test | Resolved |
+| SE R13 F1 — rustdoc label-trim caller obligation | SE | Low | Rustdoc clarification | Resolved |
+| SA R11 F1 — rendering half of `cmd_list` extraction | SA | Medium | Focused pre-Layer-7 PR | Open / Deferred |
+
+Round-2 closure pass (SO 19 / SA 12 / QE 14 / SE 14) confirms each domain's Round-1 findings are resolved or deferred-with-named-layer. Refinement loop progression: substantive findings (Round 1) → all-resolved or deferred-with-named-layer (Round 2). MVR reached for Layer 5 substantive review: the only Open finding (SA R11 F1) is a deferral to a named future layer with prior-round precedent (SA R10 deferred the same finding's predecessor with the same disposition).
+
+### Process-integrity audit
+
+- **Phase 2a/2b boundary:** Verified at Round-1 (Review 13). `7d1ca57` Red Gate commit + `bd15a9d` implementation commit + `#[allow(dead_code)]` add/remove pattern confirms a real (not performative) Red Gate. Round-2 inline fixes commit `7f9bae4` does not touch Phase 2a/2b artifacts.
+- **Round numbering:** SO 18→19, SA 11→12, QE 13→14, SE 13→14, VDD-IAR 13→14. Consistent monotonic sequence; no skipped rounds; round labels match cadence convention.
+- **Cat B Red Gate disposition:** Audited at SO Review 18 and QE Review 13. Both cold-session reviewers confirmed the Cat B labelling for the 7 integration tests is honest (the AND-combination was emergent from prior layers' chained retains; cf. Layer 3/4 prior Cat B precedent).
+- **Manual testing closure:** Round-1 (Dim 6) confirmed the 6 manual checks were executed. Round-2 SO F3 fix tightens the TODO.md setup wording so a future external reviewer can reproduce the steps from the document alone — additive process improvement, not a defect.
+
+### Merge-gate verdict
+
+**GO.** All five active Layer-5 IAR domains report MVR or deferred-with-named-layer. The refinement loop produced real findings → fixes → no new findings on the closure pass. The merge-gate criteria from `iterative-adversarial-refinement/README.md` § Merging gate are satisfied:
+
+1. ✓ All active IAR domains have run at least one full pass on Layer 5 (Round 1 cold-batch).
+2. ✓ The refinement loop continued until MVR (Round 2 closure pass produced 0 new findings).
+3. ✓ Every finding is Resolved (5) or Deferred-with-named-layer (1, SA R11 F1 → focused pre-Layer-7 PR).
+4. ✓ VDD-IAR Alignment has run as the final gate step (this round).
+5. ✓ Round numbers and session context logged in respective domain files.
+
+Layer 5 is cleared to merge.
+
+### Files modified
+
+Only this log appended.
+
+---
+

--- a/issue-tracker-cli/src/lib.rs
+++ b/issue-tracker-cli/src/lib.rs
@@ -421,7 +421,11 @@ pub fn label_matches(labels: &[String], filter: &str) -> bool {
 /// Per DESIGN.md Feature 2 / Edge Cases / Labels, label comparison is
 /// case-sensitive and exact-match; priority and status comparisons assume the
 /// caller has already normalized the filter values (lowercase) and that stored
-/// values are normalized at write/load time.
+/// values are normalized at write/load time. The caller is also responsible
+/// for applying any other normalization the spec requires before calling —
+/// notably trimming the label filter (DESIGN.md Edge Cases / Labels mandates
+/// trim-on-store / trim-on-filter symmetry; `cmd_list` runs `parse_label` on
+/// the filter value to satisfy this).
 fn issue_matches_filters(
     issue: &Issue,
     status: &str,
@@ -486,13 +490,15 @@ pub fn cmd_list(
         Some(l) => Some(parse_label(l)?),
         None => None,
     };
-    // Disjunction over non-default filters: any future filter (e.g. Layer 6's
-    // `--description-contains`) must extend `extra_filter_active` here — a single
-    // location — rather than appending another `&& *_filter.is_none()` conjunct
-    // to the empty-state predicate. Reduces the SO Review 11 regression hazard:
-    // the structural fragility of the positive-enumeration form is what made the
-    // earlier empty-state heuristic break when `--priority` was added in Layer 3
-    // and again when `--label` was added in Layer 4. SA Review 9 Finding 2.
+    // Disjunction over non-default filters: any new filter the spec is amended
+    // to add must extend `extra_filter_active` here — a single location —
+    // rather than appending another `&& *_filter.is_none()` conjunct to the
+    // empty-state predicate. Reduces the SO Review 11 regression hazard: the
+    // structural fragility of the positive-enumeration form is what made the
+    // earlier empty-state heuristic break when `--priority` was added in
+    // Layer 3 and again when `--label` was added in Layer 4. SA Review 9
+    // Finding 2. (DESIGN.md "Out of Scope" excludes text search; the
+    // disjunction is shaped for spec-amended filters, not anticipated ones.)
     let extra_filter_active = effective_priority.is_some() || effective_label.is_some();
     let is_default_open_view = effective_status == "open" && !extra_filter_active;
 
@@ -927,6 +933,23 @@ mod tests {
         let issue = issue_with("open", "high", &["bug"]);
         assert!(issue_matches_filters(&issue, "open", None, Some("bug")));
         assert!(!issue_matches_filters(&issue, "open", None, Some("Bug")));
+    }
+
+    #[test]
+    fn filter_and_logic_is_not_or_between_optional_conjuncts() {
+        // Defense-in-depth (QE Review 13 F1) against `&&` → `||` between the
+        // priority and label conjuncts: an issue that mismatches BOTH optional
+        // filters (matching status only) must still reject. The three
+        // single-mismatch subcases of filter_and_logic_all_must_match each
+        // mismatch exactly one filter, so a between-optional `||` mutation
+        // would survive them — this case mismatches both optionals at once.
+        let issue = issue_with("open", "medium", &["bug"]);
+        assert!(!issue_matches_filters(
+            &issue,
+            "open",
+            Some("high"),
+            Some("feature")
+        ));
     }
 
     #[test]

--- a/issue-tracker-cli/src/lib.rs
+++ b/issue-tracker-cli/src/lib.rs
@@ -413,6 +413,32 @@ pub fn label_matches(labels: &[String], filter: &str) -> bool {
     labels.iter().any(|l| l == filter)
 }
 
+/// Returns `true` iff `issue` matches every supplied filter.
+///
+/// The `status` filter is required (the default-open view passes `"open"`); the
+/// `priority` and `label` filters are optional (an absent filter is a wildcard).
+/// Filters AND-combine: a filter that mismatches makes the whole predicate false.
+/// Per DESIGN.md Feature 2 / Edge Cases / Labels, label comparison is
+/// case-sensitive and exact-match; priority and status comparisons assume the
+/// caller has already normalized the filter values (lowercase) and that stored
+/// values are normalized at write/load time.
+// Phase 2a Red Gate: cmd_list does not yet call this predicate, so the non-test
+// lib build sees it as dead code. The unit tests in `mod tests` exercise the
+// stub and (will, at Phase 2b) the real implementation. The allow is removed at
+// Phase 2b once cmd_list adopts the predicate.
+#[allow(dead_code)]
+fn issue_matches_filters(
+    issue: &Issue,
+    status: &str,
+    priority: Option<&str>,
+    label: Option<&str>,
+) -> bool {
+    // Stub: Phase 2a Red Gate. Bind args so Phase 2a compile is warning-free
+    // under -D warnings; Phase 2b will replace this body with the real predicate.
+    let _ = (issue, status, priority, label);
+    todo!("Layer 5: extract AND-logic predicate from cmd_list's chained retain calls")
+}
+
 fn truncate_with_ellipsis(s: &str, max_chars: usize) -> String {
     let chars: Vec<char> = s.chars().collect();
     if chars.len() <= max_chars {
@@ -825,6 +851,87 @@ mod tests {
         let mut ok = issue(1, "medium");
         ok.labels = vec!["bug".to_string(), "auth".to_string()];
         assert!(issue_fields_are_valid(&ok));
+    }
+
+    // --- Layer 5: compound-filter predicate (Red Gate) ---
+
+    fn issue_with(status: &str, priority: &str, labels: &[&str]) -> Issue {
+        Issue {
+            id: 1,
+            title: "x".to_string(),
+            description: None,
+            status: status.to_string(),
+            priority: priority.to_string(),
+            labels: labels.iter().map(|s| s.to_string()).collect(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn filter_and_logic_all_present_returns_true() {
+        // DESIGN.md Feature 2: status, priority, label are AND-combined; an
+        // issue matching all three filters must be present in results.
+        let issue = issue_with("open", "high", &["bug"]);
+        assert!(issue_matches_filters(
+            &issue,
+            "open",
+            Some("high"),
+            Some("bug")
+        ));
+    }
+
+    #[test]
+    fn filter_and_logic_all_must_match() {
+        // AND, not OR: an issue that satisfies 2/3 filters must NOT pass the
+        // predicate. Three subcases — each filter independently is the
+        // odd-one-out — kill mutations that drop any single conjunct.
+        let issue = issue_with("open", "high", &["bug"]);
+
+        // status mismatch (priority + label match)
+        assert!(
+            !issue_matches_filters(&issue, "done", Some("high"), Some("bug")),
+            "status mismatch must reject even when priority and label match"
+        );
+        // priority mismatch (status + label match)
+        assert!(
+            !issue_matches_filters(&issue, "open", Some("low"), Some("bug")),
+            "priority mismatch must reject even when status and label match"
+        );
+        // label mismatch (status + priority match)
+        assert!(
+            !issue_matches_filters(&issue, "open", Some("high"), Some("feature")),
+            "label mismatch must reject even when status and priority match"
+        );
+    }
+
+    #[test]
+    fn filter_status_only_matches_any_priority_and_labels() {
+        // Optional filters absent → wildcard. Status-only filter accepts any
+        // priority and any (including empty) label set.
+        let high_with_bug = issue_with("open", "high", &["bug"]);
+        let low_no_labels = issue_with("open", "low", &[]);
+        assert!(issue_matches_filters(&high_with_bug, "open", None, None));
+        assert!(issue_matches_filters(&low_no_labels, "open", None, None));
+    }
+
+    #[test]
+    fn filter_status_mismatch_rejects_regardless_of_optional_filters() {
+        // Status is a required filter (cmd_list always supplies one — default
+        // "open" or the user's --status value). A mismatched status rejects
+        // even when no optional filters are present.
+        let issue = issue_with("done", "high", &["bug"]);
+        assert!(!issue_matches_filters(&issue, "open", None, None));
+    }
+
+    #[test]
+    fn filter_label_match_is_case_sensitive() {
+        // Predicate-level corollary of label_filter_case_sensitive_match: the
+        // compound predicate must inherit the case-sensitive contract from
+        // label_matches, not silently lowercase.
+        let issue = issue_with("open", "high", &["bug"]);
+        assert!(issue_matches_filters(&issue, "open", None, Some("bug")));
+        assert!(!issue_matches_filters(&issue, "open", None, Some("Bug")));
     }
 
     #[test]

--- a/issue-tracker-cli/src/lib.rs
+++ b/issue-tracker-cli/src/lib.rs
@@ -422,21 +422,15 @@ pub fn label_matches(labels: &[String], filter: &str) -> bool {
 /// case-sensitive and exact-match; priority and status comparisons assume the
 /// caller has already normalized the filter values (lowercase) and that stored
 /// values are normalized at write/load time.
-// Phase 2a Red Gate: cmd_list does not yet call this predicate, so the non-test
-// lib build sees it as dead code. The unit tests in `mod tests` exercise the
-// stub and (will, at Phase 2b) the real implementation. The allow is removed at
-// Phase 2b once cmd_list adopts the predicate.
-#[allow(dead_code)]
 fn issue_matches_filters(
     issue: &Issue,
     status: &str,
     priority: Option<&str>,
     label: Option<&str>,
 ) -> bool {
-    // Stub: Phase 2a Red Gate. Bind args so Phase 2a compile is warning-free
-    // under -D warnings; Phase 2b will replace this body with the real predicate.
-    let _ = (issue, status, priority, label);
-    todo!("Layer 5: extract AND-logic predicate from cmd_list's chained retain calls")
+    issue.status == status
+        && priority.is_none_or(|p| issue.priority == p)
+        && label.is_none_or(|l| label_matches(&issue.labels, l))
 }
 
 fn truncate_with_ellipsis(s: &str, max_chars: usize) -> String {
@@ -503,13 +497,14 @@ pub fn cmd_list(
     let is_default_open_view = effective_status == "open" && !extra_filter_active;
 
     let mut issues = load_issues(issues_path)?;
-    issues.retain(|i| i.status == effective_status);
-    if let Some(p) = &effective_priority {
-        issues.retain(|i| &i.priority == p);
-    }
-    if let Some(l) = &effective_label {
-        issues.retain(|i| label_matches(&i.labels, l));
-    }
+    issues.retain(|i| {
+        issue_matches_filters(
+            i,
+            &effective_status,
+            effective_priority.as_deref(),
+            effective_label.as_deref(),
+        )
+    });
 
     if issues.is_empty() {
         // Empty-state messages route to stderr per DESIGN.md "stderr contract" /

--- a/issue-tracker-cli/tests/layer5.rs
+++ b/issue-tracker-cli/tests/layer5.rs
@@ -1,0 +1,384 @@
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+mod common;
+use common::tracker;
+
+// Layer 5 — Compound Filtering (status × priority × label, AND-combined)
+//
+// DESIGN.md Feature 2 (lines 63, 321): "--status, --priority, and --label are
+// AND-combined. An issue must match all provided filters to appear." Layer 3
+// added --priority filtering and Layer 4 added --label filtering on top of the
+// Layer 2 --status filter; the AND-combination is an emergent property of
+// cmd_list's chained `retain()` calls. Layer 5 adds the explicit assertions.
+//
+// Most CLI tests below are **Cat B Red Gate deviations**: the compound-filter
+// behavior already exists from Layers 3 and 4, so the integration tests pass
+// against the current implementation rather than failing first. They are
+// regression coverage of the layer plan's acceptance criteria, not Red Gate
+// tests for new behavior. The genuine Cat A Red Gate for this layer is the
+// `issue_matches_filters` predicate extracted from cmd_list — its unit tests
+// in `src/lib.rs::tests` panic against the `todo!()` stub until Phase 2b
+// implements the predicate. Same disposition as Layer 3's
+// `create_without_priority_defaults_to_medium` and Layer 4's two Cat B
+// deviations (see Layer 4 Red Gate commit 14bd219).
+
+// --- Two-filter AND combinations (DESIGN.md AC 1, 2, 3) ---
+
+#[test]
+fn list_status_and_priority_filter_and_combination() {
+    // Cat B Red Gate deviation. AC: `tracker list --status open --priority high`
+    // shows only issues that are both open AND high-priority. Setup gives one
+    // issue matching both, plus three single-mismatch issues that are NOT in
+    // the result. Negative assertions kill mutations that route the second
+    // filter to OR semantics or drop the second retain.
+    let dir = TempDir::new().unwrap();
+    tracker(&dir)
+        .args(["create", "Match all", "--priority", "high"])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args(["create", "Wrong priority", "--priority", "low"])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args(["create", "Wrong status", "--priority", "high"])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args(["status", "3", "done"])
+        .assert()
+        .success();
+
+    let output = tracker(&dir)
+        .args(["list", "--status", "open", "--priority", "high"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let out = String::from_utf8(output).unwrap();
+    assert!(
+        out.contains("Match all"),
+        "issue matching both filters must appear:\n{out}"
+    );
+    assert!(
+        !out.contains("Wrong priority"),
+        "issue matching only --status must NOT appear (AND, not OR):\n{out}"
+    );
+    assert!(
+        !out.contains("Wrong status"),
+        "issue matching only --priority must NOT appear (AND, not OR):\n{out}"
+    );
+}
+
+#[test]
+fn list_status_and_label_filter_and_combination() {
+    // Cat B Red Gate deviation. AC: `tracker list --status open --label bug`
+    // shows only open issues with label `bug`.
+    let dir = TempDir::new().unwrap();
+    tracker(&dir)
+        .args(["create", "Match all", "--label", "bug"])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args(["create", "Wrong label", "--label", "feature"])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args(["create", "Wrong status", "--label", "bug"])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args(["status", "3", "done"])
+        .assert()
+        .success();
+
+    let output = tracker(&dir)
+        .args(["list", "--status", "open", "--label", "bug"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let out = String::from_utf8(output).unwrap();
+    assert!(
+        out.contains("Match all"),
+        "issue matching both filters must appear:\n{out}"
+    );
+    assert!(
+        !out.contains("Wrong label"),
+        "issue matching only --status must NOT appear:\n{out}"
+    );
+    assert!(
+        !out.contains("Wrong status"),
+        "issue matching only --label must NOT appear:\n{out}"
+    );
+}
+
+#[test]
+fn list_priority_and_label_filter_and_combination() {
+    // Cat B Red Gate deviation. AC: `tracker list --priority high --label bug`
+    // shows only high-priority issues with label `bug`. Note this exercises
+    // the non-default-status path: with no --status flag, effective_status is
+    // "open" and only open issues participate; one of the setup issues is in-
+    // progress to confirm it is filtered out by the implicit status default.
+    let dir = TempDir::new().unwrap();
+    tracker(&dir)
+        .args([
+            "create",
+            "Match all",
+            "--priority",
+            "high",
+            "--label",
+            "bug",
+        ])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args([
+            "create",
+            "Wrong priority",
+            "--priority",
+            "low",
+            "--label",
+            "bug",
+        ])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args([
+            "create",
+            "Wrong label",
+            "--priority",
+            "high",
+            "--label",
+            "feature",
+        ])
+        .assert()
+        .success();
+
+    let output = tracker(&dir)
+        .args(["list", "--priority", "high", "--label", "bug"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let out = String::from_utf8(output).unwrap();
+    assert!(
+        out.contains("Match all"),
+        "issue matching both filters must appear:\n{out}"
+    );
+    assert!(
+        !out.contains("Wrong priority"),
+        "issue matching only --label must NOT appear:\n{out}"
+    );
+    assert!(
+        !out.contains("Wrong label"),
+        "issue matching only --priority must NOT appear:\n{out}"
+    );
+}
+
+// --- Three-filter AND (DESIGN.md AC 4 + AC 5) ---
+
+#[test]
+fn list_three_filter_and_combination() {
+    // Cat B Red Gate deviation. AC 4: `tracker list --status open --priority
+    // high --label bug` shows only issues matching all three. The setup also
+    // covers AC 5 ("an issue that matches two of three filters but not the
+    // third does NOT appear"): three of the four issues each fail exactly one
+    // filter, so a regression that ORs filters or drops a conjunct would
+    // surface them in the output.
+    let dir = TempDir::new().unwrap();
+    // Issue 1 — matches all three (the only expected result)
+    tracker(&dir)
+        .args([
+            "create",
+            "Triple match",
+            "--priority",
+            "high",
+            "--label",
+            "bug",
+        ])
+        .assert()
+        .success();
+    // Issue 2 — open + high + (label=feature) — fails label
+    tracker(&dir)
+        .args([
+            "create",
+            "Wrong label only",
+            "--priority",
+            "high",
+            "--label",
+            "feature",
+        ])
+        .assert()
+        .success();
+    // Issue 3 — open + (priority=medium) + bug — fails priority
+    tracker(&dir)
+        .args([
+            "create",
+            "Wrong priority only",
+            "--priority",
+            "medium",
+            "--label",
+            "bug",
+        ])
+        .assert()
+        .success();
+    // Issue 4 — (will be marked done) + high + bug — fails status
+    tracker(&dir)
+        .args([
+            "create",
+            "Wrong status only",
+            "--priority",
+            "high",
+            "--label",
+            "bug",
+        ])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args(["status", "4", "done"])
+        .assert()
+        .success();
+
+    let output = tracker(&dir)
+        .args([
+            "list",
+            "--status",
+            "open",
+            "--priority",
+            "high",
+            "--label",
+            "bug",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let out = String::from_utf8(output).unwrap();
+    assert!(
+        out.contains("Triple match"),
+        "issue matching all three filters must appear:\n{out}"
+    );
+    assert!(
+        !out.contains("Wrong label only"),
+        "AC 5: 2/3 match (label fails) must NOT appear:\n{out}"
+    );
+    assert!(
+        !out.contains("Wrong priority only"),
+        "AC 5: 2/3 match (priority fails) must NOT appear:\n{out}"
+    );
+    assert!(
+        !out.contains("Wrong status only"),
+        "AC 5: 2/3 match (status fails) must NOT appear:\n{out}"
+    );
+}
+
+// --- Empty-state messaging in compound-filter contexts ---
+
+#[test]
+fn list_compound_two_filter_no_match_shows_filter_message() {
+    // Cat B Red Gate deviation. AC 6: `tracker list --status done --priority
+    // low` with no matching issues prints `No issues match the given filters.`
+    // (filter message — not the default-view "No open issues. Nice work!"
+    // empty-state). Setup has issues that match neither filter together;
+    // confirms the cmd_list `is_default_open_view` heuristic correctly routes
+    // to the filter-message branch when extra_filter_active is true.
+    let dir = TempDir::new().unwrap();
+    tracker(&dir)
+        .args(["create", "High open", "--priority", "high"])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args(["create", "Low open", "--priority", "low"])
+        .assert()
+        .success();
+
+    tracker(&dir)
+        .args(["list", "--status", "done", "--priority", "low"])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "No issues match the given filters.",
+        ))
+        .stderr(predicate::str::contains("Nice work!").not());
+}
+
+#[test]
+fn list_compound_three_filter_no_match_shows_filter_message() {
+    // Cat B Red Gate deviation. AC 7: `tracker list --status open --priority
+    // high --label nonexistent` with no matching issues prints
+    // `No issues match the given filters.`. The label filter alone is the
+    // odd-one-out, so a regression that dropped --label from the
+    // extra_filter_active disjunction (SO Review 11 hazard) would route to
+    // "No open issues. Nice work!" instead.
+    let dir = TempDir::new().unwrap();
+    tracker(&dir)
+        .args([
+            "create",
+            "High open bug",
+            "--priority",
+            "high",
+            "--label",
+            "bug",
+        ])
+        .assert()
+        .success();
+
+    tracker(&dir)
+        .args([
+            "list",
+            "--status",
+            "open",
+            "--priority",
+            "high",
+            "--label",
+            "nonexistent",
+        ])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "No issues match the given filters.",
+        ))
+        .stderr(predicate::str::contains("Nice work!").not());
+}
+
+#[test]
+fn list_default_view_with_open_issues_does_not_show_filter_message() {
+    // Cat B Red Gate deviation. AC 8: `tracker list` (default, all open, some
+    // exist) shows only open issues, not `No issues match` message. Confirms
+    // the empty-state branch is skipped entirely when results are non-empty
+    // (a regression that always printed the filter message regardless of
+    // result set would surface here).
+    let dir = TempDir::new().unwrap();
+    tracker(&dir)
+        .args(["create", "Open issue alpha"])
+        .assert()
+        .success();
+    tracker(&dir)
+        .args(["create", "Open issue beta"])
+        .assert()
+        .success();
+
+    let assert = tracker(&dir).args(["list"]).assert().success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stdout.contains("Open issue alpha") && stdout.contains("Open issue beta"),
+        "default `list` must show open issues:\nstdout:\n{stdout}"
+    );
+    assert!(
+        !stderr.contains("No issues match"),
+        "default-view non-empty list must NOT print the filter empty-state:\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Nice work!"),
+        "default-view non-empty list must NOT print the empty-tracker message either:\nstderr:\n{stderr}"
+    );
+}

--- a/issue-tracker-cli/tests/layer5.rs
+++ b/issue-tracker-cli/tests/layer5.rs
@@ -119,10 +119,10 @@ fn list_status_and_label_filter_and_combination() {
 #[test]
 fn list_priority_and_label_filter_and_combination() {
     // Cat B Red Gate deviation. AC: `tracker list --priority high --label bug`
-    // shows only high-priority issues with label `bug`. Note this exercises
-    // the non-default-status path: with no --status flag, effective_status is
-    // "open" and only open issues participate; one of the setup issues is in-
-    // progress to confirm it is filtered out by the implicit status default.
+    // shows only high-priority issues with label `bug`. With no --status flag,
+    // effective_status defaults to "open" — all three setup issues are open,
+    // so the AND-combination of the priority and label filters is what
+    // excludes the two single-mismatch issues from the result.
     let dir = TempDir::new().unwrap();
     tracker(&dir)
         .args([


### PR DESCRIPTION
## What this PR does

**Project:** `issue-tracker-cli`
**Layer:** 5 (Compound Filtering — `--status`, `--priority`, `--label` AND-combined; correct empty-state messaging)
**TODO.md items covered:** all 8 acceptance criteria at `TODO.md:244-251`; all 6 manual testing checklist items at `TODO.md:255-261`.

The compound-filter behavior was already emergent from the chained `retain()` calls added in Layer 3 (`--priority`) and Layer 4 (`--label`); Layer 5 extracts the AND-logic into a named pure predicate (`issue_matches_filters`) so it is testable in isolation, adds explicit acceptance-criterion coverage for each compound path, and ratifies the manual testing checklist.

## Layer gate checklist

- [x] All acceptance criteria in TODO.md are met
- [x] Tests pass (see project-specific command below)
- [x] Manual testing checklist in TODO.md completed
- [x] IAR suite run (see `iterative-adversarial-refinement/README.md`); all domains complete; all findings resolved, dismissed, or deferred to a named future layer
- [x] `CHANGELOG.md` updated
- [ ] `DECISIONS.md` updated (if decisions were made)
  - N/A — no architectural decisions made; predicate extraction is an internal refactor with no spec-visible behavior change.

### Project-specific checks

**issue-tracker-cli:**
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo audit` clean (0 advisories) — last verified clean at Layer 4 Round 2; no dependency changes in Layer 5

## Test results

| Suite | Result |
|---|---|
| `cargo test --locked --no-fail-fast` | **136/136 passed** (45 unit + 32 layer1 + 18 layer2 + 9 layer3 + 25 layer4 + 7 layer5) |
| `cargo clippy --all-targets --locked -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| Manual testing (TODO.md Layer 5 checklist) | 6/6 executed; expected outputs reproduced |

## Notes

**Commits:**
- `7d1ca57` — Phase 2a Red Gate (compound-filter tests + `issue_matches_filters` `todo!()` stub; 5 unit tests panic Cat A, 7 integration tests pass Cat B)
- `bd15a9d` — Phase 2b implementation (predicate body + `cmd_list` retain refactor)
- `da0fd8d` — Manual testing checklist completion
- `7f9bae4` — IAR Round 2 inline fixes (5 substantive findings closed)
- `3139a2d` — Round 1 cold-batch + Round 2 closure log entries (5 review files)
- `e137392` — CHANGELOG.md Layer 5 entry

**Cat B Red Gate disposition:** The 7 integration tests in `tests/layer5.rs` are explicitly classified as **Cat B Red Gate deviations** in their file header — they pass against the existing implementation because the AND-combination was emergent from prior layers' chained `retain()` calls. The genuine Cat A Red Gate is the 5 unit tests on the new `issue_matches_filters` predicate, which panicked against the `todo!()` stub at Phase 2a and pass at Phase 2b. SO Review 18 and QE Review 13 audited this disposition adversarially and confirmed it honest. Same disposition pattern as Layer 3's `create_without_priority_defaults_to_medium` and Layer 4's two Cat B deviations.

**IAR suite outcome:**
- 5 cold-session domain reviewers in Round 1 (SO 18, SA 11, QE 13, SE 13, VDD-IAR 13)
- 5 substantive Low Open findings: SO F1 (anticipatory `--description-contains` comment), SO F2 (test docstring fidelity), SO F3 (manual checklist setup wording), QE F1 (defense-in-depth unit test for `&&`→`||`), SE F1 (rustdoc trim-normalization caller obligation)
- All 5 closed inline in `7f9bae4` (Round 2 closure)
- 1 carry-forward Open: **SA R11 F1** (rendering half of `cmd_list` extraction — column-width literals and `format_*_row` helpers) is **deferred to a focused pre-Layer-7 PR** per the SA R10 disposition that introduced the deferral. This is bookkept and does not block Layer 5.
- VDD-IAR Review 14 merge-gate verdict: **GO** (all five `README.md` § Merging gate criteria satisfied).

**No DESIGN.md amendments this layer.** The compound-filter behavior was already specified in DESIGN.md Feature 2 line 63 ("`--status`, `--priority`, and `--label` are AND-combined") and line 71 (filter empty-state messaging); Layer 5 implements what was already specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)